### PR TITLE
Move math import to module level and clean up formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,4 +49,3 @@ omit = ["tests/*", ".venv/*"]
 [tool.coverage.report]
 show_missing = true
 fail_under = 0
-

--- a/scripts/update_jobs.py
+++ b/scripts/update_jobs.py
@@ -14,6 +14,7 @@ Performance Optimizations:
 """
 
 import json
+import math
 import os
 import re
 import sys
@@ -970,7 +971,6 @@ def get_job_key(job: Dict[str, Any]) -> str:
             return ''
         if isinstance(value, float):
             # Handle NaN and other floats
-            import math
             if math.isnan(value):
                 return ''
             return str(value)


### PR DESCRIPTION
## Linked Issue

Fixes #21

## Summary

Moved inline `import math` from `safe_str()` (line 973) to the module-level import block (line 17), maintaining alphabetical ordering per PEP 8.

## Testing

- `python -m py_compile scripts/update_jobs.py` — passes
- `pytest tests/ -v` — all 47 tests pass
- `pre-commit run --all-files` — all hooks pass

## Notes for Reviewer

Two-line change. No logic modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor code cleanup and formatting adjustments to improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->