### PR TITLE
feat: add timeout parameter to fetch functions

### DIFF
--- a/scripts/update_jobs.py
+++ b/scripts/update_jobs.py
@@ -89,6 +89,8 @@ def create_optimized_session() -> requests.Session:
 # Global session for connection reuse across all requests
 HTTP_SESSION = create_optimized_session()
 
+# Default timeout for HTTP requests (can be overridden via parameter)
+DEFAULT_TIMEOUT = 5
 # ============================================================================
 # COMPANY CLASSIFICATIONS
 # ============================================================================
@@ -388,7 +390,7 @@ def is_job_closed(title: str, description: str = '') -> bool:
     closed_indicators = ['closed', 'no longer accepting', 'position filled', 'expired']
     return any(indicator in combined for indicator in closed_indicators)
 
-def fetch_greenhouse_jobs(company_name: str, url: str, max_retries: int = 2) -> List[Dict[str, Any]]:
+def fetch_greenhouse_jobs(company_name: str, url: str, max_retries: int = 2, timeout: int = DEFAULT_TIMEOUT) -> List[Dict[str, Any]]:
     """Fetch jobs from Greenhouse API with retry logic"""
     jobs = []
     for attempt in range(max_retries + 1):
@@ -398,7 +400,7 @@ def fetch_greenhouse_jobs(company_name: str, url: str, max_retries: int = 2) -> 
                 time.sleep(1)  # Wait before retry
 
             print(f"Fetching jobs from {company_name} (Greenhouse)...")
-            response = HTTP_SESSION.get(url, timeout=5)  # AGGRESSIVE: 5s for 10K companies
+            response = HTTP_SESSION.get(url, timeout=timeout)  # AGGRESSIVE: 5s for 10K companies
             response.raise_for_status()
             data = response.json()
 
@@ -444,7 +446,7 @@ def fetch_greenhouse_jobs(company_name: str, url: str, max_retries: int = 2) -> 
 
     return jobs
 
-def fetch_lever_jobs(company_name: str, url: str, max_retries: int = 2) -> List[Dict[str, Any]]:
+def fetch_lever_jobs(company_name: str, url: str, max_retries: int = 2, timeout: int = DEFAULT_TIMEOUT) -> List[Dict[str, Any]]:
     """Fetch jobs from Lever API with retry logic"""
     jobs = []
     for attempt in range(max_retries + 1):
@@ -454,7 +456,7 @@ def fetch_lever_jobs(company_name: str, url: str, max_retries: int = 2) -> List[
                 time.sleep(1)  # Wait before retry
 
             print(f"Fetching jobs from {company_name} (Lever)...")
-            response = HTTP_SESSION.get(url, timeout=5)  # AGGRESSIVE: 5s for 10K companies
+            response = HTTP_SESSION.get(url, timeout=timeout)  # AGGRESSIVE: 5s for 10K companies
             response.raise_for_status()
             data = response.json()
 
@@ -500,7 +502,7 @@ def fetch_lever_jobs(company_name: str, url: str, max_retries: int = 2) -> List[
 
     return jobs
 
-def fetch_google_jobs(search_terms: List[str], max_retries: int = 2) -> List[Dict[str, Any]]:
+def fetch_google_jobs(search_terms: List[str], max_retries: int = 2, timeout: int = DEFAULT_TIMEOUT) -> List[Dict[str, Any]]:
     """Fetch jobs from Google Careers API with retry logic"""
     all_jobs = []
 
@@ -517,7 +519,7 @@ def fetch_google_jobs(search_terms: List[str], max_retries: int = 2) -> List[Dic
                 search_query = search_term.replace(' ', '%20')
                 url = f"https://careers.google.com/api/v3/search/?location=United States&q={search_query}&page_size=100"
 
-                response = HTTP_SESSION.get(url, timeout=5)  # AGGRESSIVE: 5s for 10K
+                response = HTTP_SESSION.get(url, timeout=timeout)  # AGGRESSIVE: 5s for 10K
                 response.raise_for_status()
                 data = response.json()
 


### PR DESCRIPTION
## Summary

This PR implements the feature requested in #58 by adding a configurable timeout parameter to the main fetch functions.

## Changes

### 1. Add DEFAULT_TIMEOUT constant
- Added `DEFAULT_TIMEOUT = 5` constant after `HTTP_SESSION` definition
- Provides a central, easily modifiable default value

### 2. Update function signatures
Added `timeout: int = DEFAULT_TIMEOUT` parameter to:
- `fetch_greenhouse_jobs()`
- `fetch_lever_jobs()`
- `fetch_google_jobs()`

### 3. Update HTTP calls
Changed hardcoded `timeout=5` to parameterized `timeout=timeout` in:
- `fetch_greenhouse_jobs()` (line 403)
- `fetch_lever_jobs()` (line 459)
- `fetch_google_jobs()` (line 522)

## Why This Matters

As mentioned in the issue:
- Hardcoded timeouts make it difficult to adapt to temporary API slowdowns
- Parameterizing allows dynamic adjustment without code changes
- Default behavior remains unchanged (5 seconds)
- Backward compatible (uses default value for existing callers)

## Acceptance Criteria

- [x] Create `DEFAULT_TIMEOUT` constant
- [x] Update function signatures and `HTTP_SESSION.get()` calls to use it
- [ ] Passes `pre-commit run --all-files`

## Testing

The changes are backward compatible:
- Existing callers continue to work without modification
- Default timeout remains 5 seconds
- New callers can specify custom timeout values

## Example Usage

```python
# Default behavior (unchanged)
jobs = fetch_greenhouse_jobs(company_name, url)

# Custom timeout for slow APIs
jobs = fetch_greenhouse_jobs(company_name, url, timeout=10)
```

Closes #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
* Enhanced timeout management for job fetching operations across all integrations. Introduced configurable timeout settings to provide improved reliability and better control over API request timing. This allows the system to adapt more effectively to varying network conditions, ensuring consistent and resilient performance when connecting to different job sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->