### PR TITLE
fix(frontend): correct footer tagline grammar

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -281,7 +281,7 @@
             </div>
         </div>
         <div class="footer-bottom">
-            <p class="footer-tagline">Built by <strong>engineer</strong>, for engineers</p>
+            <p class="footer-tagline">Built by <strong>engineers</strong>, for engineers</p>
             <p>Made By: <strong>Ritesh Rana</strong></p>
             <p>Contact: <a href="mailto:contact@riteshrana.engineer">contact@riteshrana.engineer</a></p>
         </div>


### PR DESCRIPTION
Fixes #111 

Corrected the footer tagline grammar in docs/index.html by changing "engineer" to "engineers".



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated footer messaging to reflect team composition.

* **Style**
  * Applied formatting adjustments for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->