### PR TITLE
fix(ci): fix urllib undef and auto-review fork permission failures

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -92,9 +92,9 @@ jobs:
 
           Payment solicitation (cryptocurrency wallet addresses or digital tipping links) was detected in the PR description or changed files. This repository does not pay contributors.
 
-          @ambicuity — please review and block the contributor if appropriate."
+          @ambicuity — please review and block the contributor if appropriate." || echo "⚠️ Could not post comment (fork permission restriction)"
 
-          gh pr close "$PR_NUMBER"
+          gh pr close "$PR_NUMBER" || echo "⚠️ Could not close PR (fork permission restriction)"
           exit 1
 
       - name: Set up Python
@@ -337,7 +337,7 @@ jobs:
             gh api --method DELETE "repos/${{ github.repository }}/issues/comments/${PREV}" 2>/dev/null || true
           fi
 
-          echo "$BODY" | gh pr comment "$PR_NUMBER" --body-file -
+          echo "$BODY" | gh pr comment "$PR_NUMBER" --body-file - || echo "⚠️ Could not post comment (likely fork permission restriction)"
 
       # ── Auto-merge config-only PRs that passed ────────────────────────────
       - name: Auto-merge config-only PR
@@ -352,7 +352,7 @@ jobs:
           echo "Config-only PR passed all checks — enabling auto-merge"
           gh pr merge "$PR_NUMBER" --auto --squash \
             --subject "$(gh pr view $PR_NUMBER --json title --jq .title)" \
-            --body "Auto-merged by automated review: all integrity checks passed ✅"
+            --body "Auto-merged by automated review: all integrity checks passed ✅" || echo "⚠️ Could not auto-merge (likely fork permission restriction)"
 
       # ── Request changes on failure ────────────────────────────────────────
       - name: Request changes on failure
@@ -362,4 +362,4 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           gh pr review "$PR_NUMBER" --request-changes \
-            --body "Automated review failed — see comment above for details on which checks failed and what to fix."
+            --body "Automated review failed — see comment above for details on which checks failed and what to fix." || echo "⚠️ Could not request changes (likely fork permission restriction)"

--- a/scripts/update_jobs.py
+++ b/scripts/update_jobs.py
@@ -2109,7 +2109,7 @@ def check_job_url_health(jobs: List[Dict[str, Any]],
             continue
             
         try:
-            parsed = urllib.parse.urlparse(url)
+            parsed = urlparse(url)
             hostname = parsed.hostname or ''
             if hostname in ('localhost', '127.0.0.1', '169.254.169.254', '0.0.0.0') or hostname.startswith(('192.168.', '10.', '172.')):
                 continue


### PR DESCRIPTION
Fixes 3 systemic CI checks that fail on all PRs:
1. **Python Lint & Syntax**: Fixed `F821 undefined name 'urllib'` in `update_jobs.py:2112`.
2. **Pre-commit**: Fixed by the above syntax fix.
3. **Automated PR Review**: Added fallback error handling (`|| echo`) to `gh pr` commands in `auto-review.yml` so the workflow doesn't fail with `Resource not accessible by integration` when read-only tokens on fork PRs prevent commenting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of automated workflows to gracefully handle permission restrictions in fork environments.

* **Chores**
  * Code quality improvement in internal scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->