### PR TITLE
fix(ci): rebase update-jobs before pushing main

### DIFF
--- a/.github/workflows/update-jobs.yml
+++ b/.github/workflows/update-jobs.yml
@@ -74,4 +74,14 @@ jobs:
             exit 0
           fi
           git commit -m "🤖 Update job listings [skip ci]"
-          git push origin main
+          for attempt in 1 2 3; do
+            git fetch origin main
+            git rebase origin/main
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "Push rejected on attempt $attempt, retrying..."
+            sleep 5
+          done
+          echo "::error::Failed to push updated job listings after 3 attempts."
+          exit 1


### PR DESCRIPTION
## Summary
- fix the `Update New Grad Jobs` workflow after the post-merge failure on `main` run `22837015453`
- rebase the generated docs commit onto the latest `origin/main` before pushing
- retry the push a few times so concurrent bot commits do not leave `main` red

## Testing
- `pre-commit run --all-files`
- `/Users/ritesh/Downloads/submission_folder/New-Grad-Jobs/.venv/bin/pytest tests/`
- `/Users/ritesh/Downloads/submission_folder/New-Grad-Jobs/.venv/bin/python test_config.py`
- `/Users/ritesh/Downloads/submission_folder/New-Grad-Jobs/.venv/bin/python -m py_compile scripts/update_jobs.py scripts/generate_companies.py test_config.py scripts/fix_nan_only.py`
- `flake8 scripts/ --count --select=E9,F63,F7,F82 --show-source --statistics`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of automated job updates. Implemented retry logic for critical git operations with up to 3 attempts and 5-second intervals between retries. Enhanced error handling provides explicit failure messages when all retry attempts are exhausted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->