### PR TITLE
fix(setup): install dev deps via pyproject extras and align docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ make setup
 
 The `make setup` command automatically:
 1. Creates a Python virtual environment (`.venv`).
-2. Installs all project and testing dependencies.
+2. Installs runtime dependencies from `requirements.txt` and dev/test tooling from `pyproject.toml` (`.[dev]`, including `pytest` and `pytest-cov`).
 3. Configures `pre-commit` hooks to run on every commit.
 
 *(Alternatively, if you use DevContainers, just open this repository in VS Code and click "Reopen in Container". Everything is pre-configured!)*

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ VENV_PIP := $(VENV)/bin/$(PIP)
 help: ## Show this help menu
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
-setup: ## First-time setup: creates virtualenv, installs all requirements (prod, dev), and configures pre-commit
+setup: ## First-time setup: creates virtualenv, installs all requirements (prod + dev/test), and configures pre-commit
 	@echo "=> Creating Python virtual environment..."
 	$(PYTHON) -m venv $(VENV)
 	@echo "=> Upgrading pip..."


### PR DESCRIPTION
## Summary
- Replaced `$(VENV_PIP) install -r tests/requirements.txt` with `$(VENV_PIP) install -e ".[dev]"` in Makefile
- `tests/requirements.txt` did not exist in the repository, causing `make setup` to fail
- Dev/test dependencies are now installed via `pyproject.toml` [dev] extras

Fixes #132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined development environment setup to install runtime and dev/test tools together and simplified dependency installation.
  * Integrated automated browser installation into the initialization workflow.
  * Added a setup completion message for clearer feedback during initialization.

* **Documentation**
  * Updated contribution/setup instructions to reflect the new, clearer dependency and setup steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->