### PR TITLE
docs(contributing): document hall of fame auto-credit flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -675,28 +675,32 @@ If you are just contributing code, you don't need to do anything! Our automated 
 
 ---
 
-
 ## 🏆 Contributors
 
-Every contribution is recognized! When your PR is merged, a maintainer will add you to our [Contributors Hall of Fame](./CONTRIBUTORS.md).
+Every contribution is recognized! When your PR is merged, our automation adds you to our [Contributors Hall of Fame](./CONTRIBUTORS.md). If automation is skipped or fails, a maintainer will add you manually.
 
 ---
+
 ## 🏆 Hall of Fame Credit
 
 Contributors are automatically added to the Hall of Fame using the workflow:
 `.github/workflows/auto-thank.yml`.
 
 ### When does it happen?
+
 - After your Pull Request (PR) is successfully merged.
 
 ### When might it not work?
+
 - If the PR is created by a bot
 - If the GitHub Actions workflow fails
 - If the workflow is skipped due to configuration conditions
 
 ### What should you do if your credit does not appear?
+
 - Comment on your PR or the related issue
 - A maintainer will review and add you manually if needed
+
 ---
 
 Thank you for helping new graduates land their first job. Every contribution matters. 🚀


### PR DESCRIPTION
## Linked Issue
Fixes #134

## Summary
Updated the Hall of Fame section in `CONTRIBUTING.md` to match the automated contributor-credit workflow, document common skip/failure cases, and provide troubleshooting guidance.

## Changes Made
| File | What changed |
|------|-------------|
| `CONTRIBUTING.md` | Added Hall of Fame auto-credit documentation, fixed wording inconsistency, and adjusted heading/list spacing in the new block. |

## Testing
- [x] `python -m py_compile scripts/update_jobs.py`
- [x] `make test`
- [x] `pre-commit run --all-files`
- [x] Targeted markdownlint check on `CONTRIBUTING.md` touched section

## Notes for Reviewer
Documentation-only change; no runtime behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor recognition guidance to describe the automated process for acknowledging contributors upon PR merge.
  * Clarified scenarios where manual follow-up may be required for missing recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->