### PR TITLE
fix(scraper): propagate UTC-safe date handling to output date paths

### DIFF
--- a/scripts/update_jobs.py
+++ b/scripts/update_jobs.py
@@ -1955,7 +1955,8 @@ def format_posted_date(posted_at: Any) -> str:
             normalized_date = normalize_date_string(posted_at, now_utc)
             posted_date = date_parser.parse(normalized_date)
 
-        diff = now_utc.replace(tzinfo=None) - _as_utc_naive(posted_date)
+        posted_date_utc = _as_utc_naive(posted_date)
+        diff = now_utc.replace(tzinfo=None) - posted_date_utc
 
         if diff.days == 0:
             return "Today"
@@ -1964,7 +1965,7 @@ def format_posted_date(posted_at: Any) -> str:
         elif diff.days < 7:
             return f"{diff.days} days ago"
         else:
-            return posted_date.strftime("%Y-%m-%d")
+            return posted_date_utc.strftime("%Y-%m-%d")
     except Exception as e:
         print(f"Warning: could not format date '{posted_at}': {e}", file=sys.stderr)
         return "Unknown"
@@ -2047,8 +2048,10 @@ def save_market_history(jobs: List[Dict[str, Any]]) -> None:
     Save daily market snapshot for historical tracking, comparisons, and ML predictions.
     Stores daily snapshots in docs/market-history.json with 90-day retention.
     """
+    now_utc = datetime.now(timezone.utc)
+
     # Create today's snapshot
-    today = datetime.now().strftime('%Y-%m-%d')
+    today = now_utc.strftime('%Y-%m-%d')
 
 
     # Count jobs by category
@@ -2083,7 +2086,7 @@ def save_market_history(jobs: List[Dict[str, Any]]) -> None:
         'top_companies': top_companies,
         'unique_companies': unique_companies,
         'avg_jobs_per_company': avg_jobs_per_company,
-        'timestamp': datetime.now().isoformat()
+        'timestamp': now_utc.isoformat()
     }
 
     # Load existing history
@@ -2114,7 +2117,7 @@ def save_market_history(jobs: List[Dict[str, Any]]) -> None:
                 break
 
     # Keep only last 90 days
-    cutoff_date = (datetime.now() - timedelta(days=90)).strftime('%Y-%m-%d')
+    cutoff_date = (now_utc - timedelta(days=90)).strftime('%Y-%m-%d')
     history = [entry for entry in history if entry['date'] >= cutoff_date]
 
     # Sort by date (oldest to newest)
@@ -2123,7 +2126,7 @@ def save_market_history(jobs: List[Dict[str, Any]]) -> None:
     # Save back to file
     history_data = {
         'meta': {
-            'last_updated': datetime.now().isoformat(),
+            'last_updated': now_utc.isoformat(),
             'total_snapshots': len(history),
             'date_range': {
                 'start': history[0]['date'] if history else None,
@@ -2331,9 +2334,13 @@ def extract_sort_date(job: Dict[str, Any]) -> datetime:
     if not posted_at:
         return datetime.min
     try:
+        now_utc = datetime.now(timezone.utc)
         if isinstance(posted_at, (int, float)):
-            return datetime.fromtimestamp(posted_at / 1000)
-        return date_parser.parse(posted_at).replace(tzinfo=None)
+            parsed = datetime.fromtimestamp(posted_at / 1000, tz=timezone.utc)
+        else:
+            normalized_date = normalize_date_string(posted_at, now_utc)
+            parsed = date_parser.parse(normalized_date)
+        return _as_utc_naive(parsed)
     except Exception:
         return datetime.min
 

--- a/tests/test_date_normalization.py
+++ b/tests/test_date_normalization.py
@@ -7,7 +7,13 @@ from datetime import datetime, timedelta, timezone
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
 
-from update_jobs import format_posted_date, get_iso_date, is_recent_job, normalize_date_string
+from update_jobs import (
+    extract_sort_date,
+    format_posted_date,
+    get_iso_date,
+    is_recent_job,
+    normalize_date_string,
+)
 
 
 FIXED_NOW_UTC = datetime(2026, 3, 4, 12, 0, 0, tzinfo=timezone.utc)
@@ -168,6 +174,30 @@ def test_get_iso_date_handles_unix_millis_in_utc(monkeypatch):
 
     recent_ms = int(datetime(2024, 3, 9, 10, 0, 0, tzinfo=timezone.utc).timestamp() * 1000)
     assert get_iso_date(recent_ms) == '2024-03-09T10:00:00'
+
+
+def test_get_iso_date_handles_none_nan_empty_and_malformed():
+    assert get_iso_date(None) == ''
+    assert get_iso_date(float('nan')) == ''
+    assert get_iso_date('') == ''
+    assert get_iso_date('not-a-date') == ''
+
+
+def test_extract_sort_date_normalizes_unix_millis_and_offset_strings(monkeypatch):
+    monkeypatch.setattr('update_jobs.datetime', _fixed_datetime_class(FIXED_NOW_UTC))
+
+    recent_ms = int((FIXED_NOW_UTC - timedelta(days=2)).timestamp() * 1000)
+    assert extract_sort_date({'posted_at': recent_ms}) == datetime(2026, 3, 2, 12, 0, 0)
+    assert extract_sort_date({'posted_at': '2026-03-01T00:30:00+14:00'}) == datetime(2026, 2, 28, 10, 30, 0)
+
+
+def test_extract_sort_date_parses_human_readable_and_invalid_values(monkeypatch):
+    monkeypatch.setattr('update_jobs.datetime', _fixed_datetime_class(FIXED_NOW_UTC))
+
+    assert extract_sort_date({'posted_at': 'Posted Today'}) == datetime(2026, 3, 4, 0, 0, 0)
+    assert extract_sort_date({'posted_at': 'not-a-date'}) == datetime.min
+    assert extract_sort_date({'posted_at': ''}) == datetime.min
+    assert extract_sort_date({'posted_at': None}) == datetime.min
 
 
 def _fixed_datetime_class(fixed_now: datetime):

--- a/tests/test_generate_jobs_json.py
+++ b/tests/test_generate_jobs_json.py
@@ -210,15 +210,8 @@ class TestJobSorting:
         companies = [job['company'] for job in result['jobs']]
         assert companies == ['B', 'D', 'A', 'C']
 
-    def test_jobs_with_datetime_objects_maintain_order(self):
-        """Jobs with datetime objects fail to parse and maintain input order.
-
-        Note: extract_sort_date() uses date_parser.parse() which raises an exception
-        for datetime objects ("Parser must be a string or character stream, not datetime").
-        All exceptions return datetime.min, so jobs maintain their original order.
-        This is expected - normalize_date_string() should convert datetimes to ISO strings
-        before jobs reach generate_jobs_json().
-        """
+    def test_jobs_with_datetime_objects_sort_correctly(self):
+        """Jobs with datetime objects should sort by datetime descending."""
         jobs = [
             {'company': 'A', 'posted_at': datetime(2026, 3, 10, 12, 0, 0)},
             {'company': 'B', 'posted_at': datetime(2026, 3, 15, 8, 30, 0)},
@@ -228,8 +221,7 @@ class TestJobSorting:
         result = generate_jobs_json(jobs, config)
 
         companies = [job['company'] for job in result['jobs']]
-        # All fail to parse, maintain input order
-        assert companies == ['A', 'B', 'C']
+        assert companies == ['C', 'B', 'A']
 
     def test_jobs_with_missing_dates_sorted_to_end(self):
         """Jobs with missing/None posted_at should appear at the end."""


### PR DESCRIPTION
## Summary
- propagate UTC-safe normalization to output date paths by ensuring `extract_sort_date()` normalizes all parsed dates through `_as_utc_naive()` and uses a UTC anchor for string normalization
- make `save_market_history()` use a single UTC anchor (`datetime.now(timezone.utc)`) for snapshot date, timestamps, and retention cutoff
- keep `format_posted_date()` display formatting UTC-consistent by formatting from normalized UTC-naive datetime
- add deterministic tests for `extract_sort_date()` edge cases and update `generate_jobs_json()` sorting expectations for datetime-object inputs

## Validation
- `pytest tests/test_date_normalization.py -q -o addopts=''`
- `pytest tests/ -q -o addopts=''`
- `pre-commit run --all-files`
- timezone determinism spot-checks under `TZ=UTC` and `TZ=America/Los_Angeles`

Fixes #96
