### PR TITLE
fix(stats): classify forecast unavailability states on /docs/stats.html

### DIFF
--- a/docs/stats.js
+++ b/docs/stats.js
@@ -122,6 +122,7 @@ async function fetchMarketHistory() {
 async function fetchPredictions() {
     const attempts = [];
     let hasFetchFailure = false;
+    let invalidDataError = null;
 
     for (const path of PREDICTION_PATHS) {
         try {
@@ -158,13 +159,9 @@ async function fetchPredictions() {
                     status: response.status,
                     message: error.message
                 });
+                invalidDataError = `Invalid JSON in predictions artifact at ${path}`;
                 console.error('Predictions artifact is not valid JSON:', { path, error: error.message });
-                return {
-                    status: 'invalid_data',
-                    data: null,
-                    attempts,
-                    error: `Invalid JSON in predictions artifact at ${path}`
-                };
+                continue;
             }
         } catch (error) {
             attempts.push({
@@ -174,6 +171,15 @@ async function fetchPredictions() {
             });
             hasFetchFailure = true;
         }
+    }
+
+    if (invalidDataError) {
+        return {
+            status: 'invalid_data',
+            data: null,
+            attempts,
+            error: invalidDataError
+        };
     }
 
     if (hasFetchFailure) {
@@ -857,7 +863,7 @@ function renderPredictions(predictionRenderState) {
             renderPredictionState(
                 container,
                 'Forecast unavailable: more history needed',
-                'Predictions appear after at least 7 daily market snapshots are collected.',
+                `Predictions appear after at least ${MIN_PREDICTION_HISTORY_SNAPSHOTS} daily market snapshots are collected.`,
                 'warning',
                 detail
             );

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -2274,7 +2274,7 @@ h3 {
     margin: 0 0 0.5rem;
     color: var(--text-primary);
     font-size: 1.05rem;
-    font-family: 'Outfit', 'Inter', sans-serif;
+    font-family: Outfit, Inter, sans-serif;
 }
 
 .prediction-state p {
@@ -2285,7 +2285,7 @@ h3 {
 
 .prediction-state .prediction-state-detail {
     margin-top: 0.75rem;
-    font-family: 'Monaco', 'Menlo', monospace;
+    font-family: Monaco, Menlo, monospace;
     font-size: 0.8rem;
     color: var(--text-tertiary);
 }


### PR DESCRIPTION
## Summary
- replace generic predictions fallback with explicit forecast states in `docs/stats.js`
- classify and render distinct states: `no_artifact`, `insufficient_history`, `fetch_failed`, `invalid_data`, `ready`
- add prediction fetch diagnostics (attempted paths, HTTP/network/parse outcomes) and clearer console logging
- add state-specific UI styles in `docs/styles.css`

## Why
Local `/docs/stats.html` showed a misleading "insufficient history" fallback even when history existed (31 snapshots) and the real issue was missing `docs/predictions.json`.

## Validation
- `node --check docs/stats.js`
- `.venv/bin/python -m pytest tests/test_predict_hiring_trends.py tests/test_readme_contract.py tests/test_save_market_history.py`
- local HTTP checks confirmed:
  - `/docs/stats.html` -> 200
  - `/docs/market-history.json` -> 200
  - `/docs/predictions.json` -> 404
- scenario checks via JS harness covered: `no_artifact`, `insufficient_history`, `fetch_failed`, `invalid_data`, `ready`

## Notes
- frontend-only fix; no new pipeline artifact format
- keeps `/docs/` local routing behavior (relative paths first)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced forecast messaging with contextual feedback for unavailable, invalid, or insufficient data scenarios.

* **Bug Fixes**
  * Improved error handling and recovery for forecast data retrieval.

* **Style**
  * Added visual styling for forecast state indicators with neutral, warning, and error variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->