### PR TITLE
feat: enrich Greenhouse descriptions via individual job endpoint

### DIFF
--- a/scripts/update_jobs.py
+++ b/scripts/update_jobs.py
@@ -784,13 +784,11 @@ _COMP_BLOCKLIST = re.compile(
 )
 
 
-def clean_description(text: Optional[str], max_chars: int = 1200) -> str:
+def clean_description(text: Optional[str], max_chars: int = 3000) -> str:
     """Strip HTML, collapse whitespace, clip to max_chars on a word boundary.
 
     Used to publish a readable "About the role" snippet in docs/jobs.json
     from the raw HTML each ATS returns in `content` / `descriptionHtml`.
-    Kept conservative at 1200 chars so jobs.json stays under ~3 MB on the
-    typical 1000-job scrape.
     """
     if not text:
         return ''
@@ -859,6 +857,13 @@ def fetch_greenhouse_jobs(company_name: str, url: str, max_retries: int = 2, tim
     if 'content=' not in url:
         url = url + ('&' if '?' in url else '?') + 'content=true'
 
+    # Extract board token for individual job fetches (e.g. 'andurilindustries'
+    # from 'https://boards-api.greenhouse.io/v1/boards/andurilindustries/jobs')
+    board_token = None
+    _bt_match = re.search(r'/boards/([^/]+)/jobs', url)
+    if _bt_match:
+        board_token = _bt_match.group(1)
+
     for attempt in range(max_retries + 1):
         try:
             if attempt > 0:
@@ -885,7 +890,9 @@ def fetch_greenhouse_jobs(company_name: str, url: str, max_retries: int = 2, tim
                 print(f"  ⚠️  {company_name}: Unexpected API response format")
                 continue
 
-            for job in data.get('jobs', []):
+            raw_jobs = data.get('jobs', [])
+
+            for job in raw_jobs:
                 description = job.get('content', '') or ''
                 jobs.append({
                     'company': company_name,
@@ -895,8 +902,28 @@ def fetch_greenhouse_jobs(company_name: str, url: str, max_retries: int = 2, tim
                     'posted_at': job.get('updated_at') or job.get('created_at'),
                     'source': 'Greenhouse',
                     'description': clean_description(description),
+                    'description_html': description,
                     'comp': extract_compensation(description),
+                    '_gh_id': job.get('id'),
                 })
+
+            # Enrichment pass: fetch individual details for jobs with empty content.
+            # Only when we have a board_token and there are jobs needing enrichment.
+            empty_jobs = [j for j in jobs if not j['description_html'] and j.get('_gh_id')]
+            if empty_jobs and board_token:
+                print(f"  📋 Enriching {len(empty_jobs)} jobs with empty descriptions...")
+                for job_dict in empty_jobs:
+                    detail = fetch_greenhouse_job_detail(board_token, job_dict['_gh_id'])
+                    if detail and detail.get('content'):
+                        content = detail['content']
+                        job_dict['description'] = clean_description(content)
+                        job_dict['description_html'] = content
+                        job_dict['comp'] = extract_compensation(content) or job_dict['comp']
+
+            # Remove internal tracking field before returning
+            for j in jobs:
+                j.pop('_gh_id', None)
+
             print(f"  ✓ Found {len(jobs)} jobs from {company_name}")
             break  # Success, exit retry loop
 
@@ -930,6 +957,31 @@ def fetch_greenhouse_jobs(company_name: str, url: str, max_retries: int = 2, tim
                 print(f"  ❌ Error fetching from {company_name} after {max_retries + 1} attempts: {e}")
 
     return jobs
+
+
+def fetch_greenhouse_job_detail(board_token: str, job_id: int, timeout: int = DEFAULT_TIMEOUT) -> Optional[Dict[str, Any]]:
+    """Fetch a single job's full details from the Greenhouse individual job endpoint.
+
+    Used as a fallback when the list endpoint returns empty content for a job.
+    The individual endpoint always returns the full description.
+
+    Args:
+        board_token: Greenhouse board token (e.g. 'andurilindustries').
+        job_id: Numeric job ID from the list response.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        Parsed JSON response dict, or None on failure.
+    """
+    url = f"https://boards-api.greenhouse.io/v1/boards/{board_token}/jobs/{job_id}"
+    try:
+        response = limited_get(url, timeout=timeout)
+        if response.status_code == 200:
+            return response.json()
+    except Exception:
+        pass
+    return None
+
 
 def fetch_lever_jobs(company_name: str, url: str, max_retries: int = 2, timeout: int = DEFAULT_TIMEOUT) -> List[Dict[str, Any]]:
     """Fetch jobs from Lever API with retry logic"""
@@ -2398,6 +2450,7 @@ def generate_jobs_json(jobs: List[Dict[str, Any]], config: Dict[str, Any]) -> Di
     # Build JSON structure
     json_jobs = []
     for job in jobs:
+        desc_html = job.get('description_html', '')
         json_jobs.append({
             'id': job.get('id', ''),
             'company': job.get('company', ''),
@@ -2413,6 +2466,8 @@ def generate_jobs_json(jobs: List[Dict[str, Any]], config: Dict[str, Any]) -> Di
             'is_closed': job.get('is_closed', False),
             'comp': job.get('comp'),
             'description': job.get('description', ''),
+            'description_html': desc_html,
+            'full_description': clean_description(desc_html, max_chars=50000) if desc_html else '',
         })
 
     return {

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -14,6 +14,7 @@ Tests cover:
 import sys
 import os
 import math
+import requests
 from datetime import datetime, timedelta, timezone, date
 from unittest.mock import patch
 
@@ -689,3 +690,165 @@ class TestCleanDescription:
     def test_empty_and_none(self):
         assert clean_description('') == ''
         assert clean_description(None) == ''
+
+
+# ---------------------------------------------------------------------------
+# Greenhouse description enrichment: fetch individual job details when list
+# endpoint returns empty content.
+# ---------------------------------------------------------------------------
+
+class TestGreenhouseDescriptionEnrichment:
+    """When the Greenhouse list endpoint returns empty content for a job,
+    the fetcher should fall back to the individual job endpoint to get
+    the full description."""
+
+    def _mock_response(self, status=200, json_body=None):
+        m = type('R', (), {})()
+        m.status_code = status
+        m.ok = 200 <= status < 300
+        m.json = lambda: (json_body or {'jobs': []})
+        m.raise_for_status = lambda: None
+        m.text = ''
+        return m
+
+    def test_enriches_jobs_with_empty_content(self):
+        """Jobs with empty content from list endpoint should be enriched
+        via individual job endpoint."""
+        list_body = {'jobs': [{
+            'id': 12345,
+            'title': 'Software Engineer',
+            'location': {'name': 'Hawthorne, CA'},
+            'absolute_url': 'https://example.com/job/12345',
+            'updated_at': '2026-05-16T10:00:00Z',
+            'content': '',
+        }]}
+        detail_body = {
+            'id': 12345,
+            'title': 'Software Engineer',
+            'location': {'name': 'Hawthorne, CA'},
+            'absolute_url': 'https://example.com/job/12345',
+            'updated_at': '2026-05-16T10:00:00Z',
+            'content': '<div><h2>About the role</h2><p>We are looking for a software engineer to join our team.</p></div>',
+        }
+
+        call_urls = []
+        def fake_get(url, *a, **kw):
+            call_urls.append(url)
+            if '/jobs/12345' in url:
+                return self._mock_response(json_body=detail_body)
+            return self._mock_response(json_body=list_body)
+
+        with patch('update_jobs.limited_get', side_effect=fake_get):
+            jobs = fetch_greenhouse_jobs('Anduril',
+                                        'https://boards-api.greenhouse.io/v1/boards/andurilindustries/jobs')
+        assert len(jobs) == 1
+        assert jobs[0]['description'] != ''
+        assert 'About the role' in jobs[0]['description']
+        # Verify the individual endpoint was called
+        assert any('/jobs/12345' in u for u in call_urls)
+
+    def test_skips_enrichment_when_content_present(self):
+        """Jobs that already have content should NOT trigger individual fetches."""
+        list_body = {'jobs': [{
+            'id': 99,
+            'title': 'Backend Engineer',
+            'location': {'name': 'SF'},
+            'absolute_url': 'https://example.com/job/99',
+            'updated_at': '2026-05-16T10:00:00Z',
+            'content': '<p>Full description already here.</p>',
+        }]}
+
+        call_urls = []
+        def fake_get(url, *a, **kw):
+            call_urls.append(url)
+            return self._mock_response(json_body=list_body)
+
+        with patch('update_jobs.limited_get', side_effect=fake_get):
+            jobs = fetch_greenhouse_jobs('Stripe',
+                                        'https://boards-api.greenhouse.io/v1/boards/stripe/jobs')
+        assert len(jobs) == 1
+        assert 'Full description' in jobs[0]['description']
+        # Should NOT have called individual endpoint
+        assert not any('/jobs/99' in u for u in call_urls)
+
+    def test_enrichment_preserves_existing_fields(self):
+        """Enriched jobs should still have all standard fields."""
+        list_body = {'jobs': [{
+            'id': 42,
+            'title': 'New Grad SWE',
+            'location': {'name': 'Austin, TX'},
+            'absolute_url': 'https://example.com/job/42',
+            'updated_at': '2026-05-10T00:00:00Z',
+            'content': '',
+        }]}
+        detail_body = {
+            'id': 42,
+            'content': '<p>The base salary range is $100,000 - $140,000.</p>',
+        }
+
+        def fake_get(url, *a, **kw):
+            if '/jobs/42' in url:
+                return self._mock_response(json_body=detail_body)
+            return self._mock_response(json_body=list_body)
+
+        with patch('update_jobs.limited_get', side_effect=fake_get):
+            jobs = fetch_greenhouse_jobs('TestCo',
+                                        'https://boards-api.greenhouse.io/v1/boards/testco/jobs')
+        assert len(jobs) == 1
+        job = jobs[0]
+        assert job['company'] == 'TestCo'
+        assert job['title'] == 'New Grad SWE'
+        assert job['location'] == 'Austin, TX'
+        assert job['source'] == 'Greenhouse'
+        assert job['comp'] is not None
+        assert job['comp']['min'] == 100000
+
+    def test_enrichment_handles_individual_fetch_failure(self):
+        """If individual fetch fails, job should still be returned with empty description."""
+        list_body = {'jobs': [{
+            'id': 77,
+            'title': 'Engineer',
+            'location': {'name': 'Remote'},
+            'absolute_url': 'https://example.com/job/77',
+            'updated_at': '2026-05-16T10:00:00Z',
+            'content': '',
+        }]}
+
+        call_count = [0]
+        def fake_get(url, *a, **kw):
+            call_count[0] += 1
+            if '/jobs/77' in url:
+                raise requests.exceptions.Timeout("timeout")
+            return self._mock_response(json_body=list_body)
+
+        with patch('update_jobs.limited_get', side_effect=fake_get):
+            jobs = fetch_greenhouse_jobs('TestCo',
+                                        'https://boards-api.greenhouse.io/v1/boards/testco/jobs')
+        assert len(jobs) == 1
+        assert jobs[0]['description'] == ''
+
+    def test_enrichment_handles_null_content(self):
+        """content=None (not just '') should also trigger enrichment."""
+        list_body = {'jobs': [{
+            'id': 88,
+            'title': 'Engineer',
+            'location': {'name': 'Remote'},
+            'absolute_url': 'https://example.com/job/88',
+            'updated_at': '2026-05-16T10:00:00Z',
+            'content': None,
+        }]}
+        detail_body = {
+            'id': 88,
+            'content': '<p>Real description here.</p>',
+        }
+
+        def fake_get(url, *a, **kw):
+            if '/jobs/88' in url:
+                return self._mock_response(json_body=detail_body)
+            return self._mock_response(json_body=list_body)
+
+        with patch('update_jobs.limited_get', side_effect=fake_get):
+            jobs = fetch_greenhouse_jobs('TestCo',
+                                        'https://boards-api.greenhouse.io/v1/boards/testco/jobs')
+        assert len(jobs) == 1
+        assert 'Real description' in jobs[0]['description']

--- a/tests/test_graphql_fetch.py
+++ b/tests/test_graphql_fetch.py
@@ -71,9 +71,9 @@ def test_get_nested_value_resolves_paths():
 
 def test_fetch_graphql_jobs_maps_fields_and_defaults_location():
     config = _make_company_config()
-    # 700 chars is below the 1200-char clean_description() ceiling, so it
-    # passes through unchanged. Use a >1200-char input to assert clipping.
-    long_description = "x" * 2000
+    # 700 chars is below the 3000-char clean_description() ceiling, so it
+    # passes through unchanged. Use a >3000-char input to assert clipping.
+    long_description = "x" * 4000
     response_payload = _make_graphql_response(
         [
             {"node": {
@@ -97,8 +97,8 @@ def test_fetch_graphql_jobs_maps_fields_and_defaults_location():
     assert job["url"] == "https://careers.acme.com/jobs/1"
     assert job["posted_at"] == "2026-03-01T00:00:00Z"
     assert job["source"] == "GraphQL"
-    # clean_description() clips at 1200 chars on a word boundary and appends "…"
-    assert len(job["description"]) <= 1201
+    # clean_description() clips at 3000 chars on a word boundary and appends "…"
+    assert len(job["description"]) <= 3001
     assert job["description"].endswith("…")
 
 


### PR DESCRIPTION
## Summary

- When Greenhouse list endpoint returns empty `content` for a job, fetch individual job details from `/{job_id}` endpoint
- Only enriches jobs that need it (performance-conscious)
- Increases `clean_description` max_chars from 1200 to 3000
- Adds `description_html` (raw HTML) and `full_description` (complete cleaned text) to jobs.json
- Gracefully handles individual fetch failures (job returned with empty description)

## Changes

- `scripts/update_jobs.py`: Added `fetch_greenhouse_job_detail()`, modified `fetch_greenhouse_jobs()` to enrich empty-content jobs, updated `generate_jobs_json()` with new fields
- `tests/test_enrichment.py`: Added `TestGreenhouseDescriptionEnrichment` with 5 tests
- `tests/test_graphql_fetch.py`: Updated for new 3000-char limit

## Testing

```bash
pytest tests/test_enrichment.py::TestGreenhouseDescriptionEnrichment -v  # 5 passed
pytest tests/ -v  # 697 passed
flake8 scripts/ --select=E9,F63,F7,F82  # clean
```

Fixes #275