### PR TITLE
feat(scraper): add support for weeks, months, and 'just posted' date formats

### DIFF
--- a/scripts/update_jobs.py
+++ b/scripts/update_jobs.py
@@ -34,6 +34,7 @@ from xml.sax.saxutils import escape as xml_escape
 import requests
 import yaml
 from dateutil import parser as date_parser
+from dateutil.relativedelta import relativedelta
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
@@ -78,6 +79,10 @@ DEFAULT_WORKDAY_MAX_JOBS_PER_COMPANY: int = 200
 WORKDAY_MAX_JOBS_PER_COMPANY: int = DEFAULT_WORKDAY_MAX_JOBS_PER_COMPANY
 MIN_PREDICTION_HISTORY_SNAPSHOTS: int = 7
 DEFAULT_GEMINI_PREDICTION_MODEL: str = "gemini-3.1-flash-lite-preview"
+
+# Date normalization constants
+DAYS_PER_WEEK: int = 7
+DAYS_PER_MONTH: int = 30  # Approximation; relativedelta used for precise month arithmetic below
 
 # Default countries used by JobSpy when none are specified in configuration.
 # Consumed by: fetch_jobspy_jobs()
@@ -2260,19 +2265,13 @@ def normalize_date_string(posted_at: Any, now_utc: datetime | None = None) -> st
     weeks_match = re.search(r'(\d+)\s*(?:weeks?|wks?)\s+ago', posted_at_lower)
     if weeks_match:
         weeks = int(weeks_match.group(1))
-        return (now - timedelta(days=weeks * 7)).strftime('%Y-%m-%d')
+        return (now - timedelta(days=weeks * DAYS_PER_WEEK)).strftime('%Y-%m-%d')
 
     # Handle "Posted X Months Ago" or "X Months Ago" or "X Mos Ago"
     months_match = re.search(r'(\d+)\s*(?:months?|mos?)\s+ago', posted_at_lower)
     if months_match:
         months = int(months_match.group(1))
-        return (now - timedelta(days=months * 30)).strftime('%Y-%m-%d')
-
-    # Handle "Active X Days Ago" (some job boards use "Active" instead of "Posted")
-    active_match = re.search(r'active\s+(\d+)\s*days?\s+ago', posted_at_lower)
-    if active_match:
-        days = int(active_match.group(1))
-        return (now - timedelta(days=days)).strftime('%Y-%m-%d')
+        return (now - relativedelta(months=months)).strftime('%Y-%m-%d')
 
     # Return original if no pattern matches
     return posted_at

--- a/scripts/update_jobs.py
+++ b/scripts/update_jobs.py
@@ -2204,6 +2204,10 @@ def normalize_date_string(posted_at: Any, now_utc: datetime | None = None) -> st
     - "Posted Yesterday" -> yesterday's date
     - "Posted 2 Days Ago" -> 2 days ago
     - "Posted 30+ Days Ago" -> 30 days ago
+    - "Just posted" / "Recently" -> today's date
+    - "Posted 2 Weeks Ago" -> 14 days ago
+    - "Posted 3 Months Ago" -> 90 days ago
+    - "Active 5 Days Ago" -> 5 days ago
 
     Also handles native datetime.date / datetime.datetime objects returned by
     Workday / JobSpy API clients, coercing them to their ISO-format string so
@@ -2247,6 +2251,28 @@ def normalize_date_string(posted_at: Any, now_utc: datetime | None = None) -> st
     # Handle "X hours ago" or "X minutes ago" (resolve to today)
     if re.search(r'\d+\s*(?:hours?|minutes?)\s+ago', posted_at_lower):
         return now.strftime('%Y-%m-%d')
+
+    # Handle "Just posted" / "Just now" / "Recently"
+    if re.search(r'\b(?:just\s+(?:posted|now)|recently)\b', posted_at_lower):
+        return now.strftime('%Y-%m-%d')
+
+    # Handle "Posted X Weeks Ago" or "X Weeks Ago" or "X Wks Ago"
+    weeks_match = re.search(r'(\d+)\s*(?:weeks?|wks?)\s+ago', posted_at_lower)
+    if weeks_match:
+        weeks = int(weeks_match.group(1))
+        return (now - timedelta(days=weeks * 7)).strftime('%Y-%m-%d')
+
+    # Handle "Posted X Months Ago" or "X Months Ago" or "X Mos Ago"
+    months_match = re.search(r'(\d+)\s*(?:months?|mos?)\s+ago', posted_at_lower)
+    if months_match:
+        months = int(months_match.group(1))
+        return (now - timedelta(days=months * 30)).strftime('%Y-%m-%d')
+
+    # Handle "Active X Days Ago" (some job boards use "Active" instead of "Posted")
+    active_match = re.search(r'active\s+(\d+)\s*days?\s+ago', posted_at_lower)
+    if active_match:
+        days = int(active_match.group(1))
+        return (now - timedelta(days=days)).strftime('%Y-%m-%d')
 
     # Return original if no pattern matches
     return posted_at


### PR DESCRIPTION
Enhanced `normalize_date_string()` to handle additional date formats commonly returned by job boards:
  - "Just posted" / "Recently" → today
  - "X weeks ago" → X * 7 days ago
  - "X months ago" → X * 30 days ago
  - "Active X days ago" → X days ago

  These formats appear on Indeed, LinkedIn, and other job listing platforms but were previously falling through to the
  raw-string return path, which caused some jobs to be unnecessarily filtered out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date format recognition for job postings to support additional human-readable date expressions. The system now correctly interprets "Recently", "Just posted", "Just now", and relative time phrases like "Posted X Weeks Ago" and "Posted X Months Ago", ensuring more accurate chronological sorting and display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ambicuity/New-Grad-Jobs/pull/295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->