### PR TITLE
fix: replace hardcoded timeout with DEFAULT_TIMEOUT constant

### DIFF
--- a/scripts/update_jobs.py
+++ b/scripts/update_jobs.py
@@ -2001,7 +2001,7 @@ def fetch_google_jobs_parallel(search_terms: List[str], max_workers: int = None)
                     print(f"  ⏭️  Google '{search_term}': skipping — source '{SOURCE_COOLDOWN.domain_key(url)}' in cooldown")
                     break
 
-                response = limited_get(url, timeout=5)  # AGGRESSIVE: 5s for 10K
+                response = limited_get(url, timeout=DEFAULT_TIMEOUT)  # AGGRESSIVE: 5s for 10K
                 if response.status_code == 403:
                     admitted = SOURCE_COOLDOWN.try_admit(url)
                     if admitted:


### PR DESCRIPTION
## What
Replaced hardcoded timeout=5 with DEFAULT_TIMEOUT constant in Google Jobs fetch.

## Why
DEFAULT_TIMEOUT already defined (line 70) and used by all other fetch functions. Last hardcoded instance.

Closes #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated timeout configuration for job data retrieval operations to use standardized settings, improving consistency across the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ambicuity/New-Grad-Jobs/pull/296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->