### PR TITLE
fix: restore market history category snapshots

### DIFF
--- a/scripts/update_jobs.py
+++ b/scripts/update_jobs.py
@@ -27,7 +27,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from datetime import date, datetime, timedelta, timezone
 from functools import lru_cache
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 from urllib.parse import urlencode, urlparse
 from xml.sax.saxutils import escape as xml_escape
 
@@ -2460,6 +2460,26 @@ def get_iso_date(posted_at: Any) -> str:
         print(f"Warning: could not parse ISO date '{posted_at}': {e}", file=sys.stderr)
         return ""
 
+
+def iter_category_ids(job: Dict[str, Any]) -> Iterator[str]:
+    """Yield normalized category IDs from enriched or legacy job category data."""
+    category_id = get_nested_value(job, 'category.id')
+    if isinstance(category_id, str):
+        normalized = category_id.strip()
+        if normalized:
+            yield normalized
+            return
+
+    legacy_categories = job.get('categories', [])
+    if not isinstance(legacy_categories, list):
+        return
+
+    for category in legacy_categories:
+        if isinstance(category, str):
+            normalized = category.strip()
+            if normalized:
+                yield normalized
+
 def generate_jobs_json(jobs: List[Dict[str, Any]], config: Dict[str, Any]) -> Dict[str, Any]:
     """Generate JSON data structure for jobs"""
 
@@ -2524,12 +2544,11 @@ def save_market_history(jobs: List[Dict[str, Any]]) -> None:
     # Create today's snapshot
     today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
 
-
     # Count jobs by category
     category_counts = Counter()
     for job in jobs:
-        for category in job.get('categories', []):
-            category_counts[category] += 1
+        for category_id in iter_category_ids(job):
+            category_counts[category_id] += 1
 
     # Count jobs by tier
     tier_counts = Counter()

--- a/scripts/update_jobs.py
+++ b/scripts/update_jobs.py
@@ -2463,6 +2463,9 @@ def get_iso_date(posted_at: Any) -> str:
 
 def iter_category_ids(job: Dict[str, Any]) -> Iterator[str]:
     """Yield normalized category IDs from enriched or legacy job category data."""
+    if not isinstance(job, dict):
+        return
+
     category_id = get_nested_value(job, 'category.id')
     if isinstance(category_id, str):
         normalized = category_id.strip()

--- a/tests/test_save_market_history.py
+++ b/tests/test_save_market_history.py
@@ -48,7 +48,7 @@ class TestSaveMarketHistoryStructure:
             {
                 'company': 'Google',
                 'categories': ['swe'],
-                'company_tier': {'tier': 'faang-plus'}
+                'company_tier': {'tier': 'faang_plus'}
             }
         ]
 
@@ -90,7 +90,7 @@ class TestSaveMarketHistoryStructure:
 
     def test_snapshot_date_format(self):
         """Snapshot date uses YYYY-MM-DD format."""
-        jobs = [{'company': 'Meta', 'categories': ['ml'], 'company_tier': {'tier': 'faang-plus'}}]
+        jobs = [{'company': 'Meta', 'categories': ['ml'], 'company_tier': {'tier': 'faang_plus'}}]
         update_jobs.save_market_history(jobs)
 
         with open(self.history_path, encoding='utf-8') as f:
@@ -128,8 +128,8 @@ class TestCategoryAndTierCounting:
     def test_counts_categories_correctly_from_singular_category_field(self):
         """Categories are counted from the enriched singular category field."""
         jobs = [
-            {'company': 'Google', 'category': {'id': 'software_engineering'}, 'company_tier': {'tier': 'faang-plus'}},
-            {'company': 'Meta', 'category': {'id': 'software_engineering'}, 'company_tier': {'tier': 'faang-plus'}},
+            {'company': 'Google', 'category': {'id': 'software_engineering'}, 'company_tier': {'tier': 'faang_plus'}},
+            {'company': 'Meta', 'category': {'id': 'software_engineering'}, 'company_tier': {'tier': 'faang_plus'}},
             {'company': 'Stripe', 'category': {'id': 'data_ml'}, 'company_tier': {'tier': 'unicorn'}},
         ]
 
@@ -148,7 +148,7 @@ class TestCategoryAndTierCounting:
                 'company': 'Google',
                 'category': {'id': 'software_engineering'},
                 'categories': ['data_ml', 'product'],
-                'company_tier': {'tier': 'faang-plus'},
+                'company_tier': {'tier': 'faang_plus'},
             },
             {
                 'company': 'Stripe',
@@ -169,8 +169,8 @@ class TestCategoryAndTierCounting:
     def test_falls_back_to_legacy_categories_list_when_category_missing(self):
         """Legacy category lists still count when enriched category data is absent."""
         jobs = [
-            {'company': 'Google', 'categories': ['swe', 'ml'], 'company_tier': {'tier': 'faang-plus'}},
-            {'company': 'Meta', 'categories': ['swe'], 'company_tier': {'tier': 'faang-plus'}},
+            {'company': 'Google', 'categories': ['swe', 'ml'], 'company_tier': {'tier': 'faang_plus'}},
+            {'company': 'Meta', 'categories': ['swe'], 'company_tier': {'tier': 'faang_plus'}},
             {'company': 'Stripe', 'categories': ['data'], 'company_tier': {'tier': 'unicorn'}},
         ]
 
@@ -191,13 +191,13 @@ class TestCategoryAndTierCounting:
                 'company': 'Google',
                 'category': {'id': None},
                 'categories': ['swe'],
-                'company_tier': {'tier': 'faang-plus'},
+                'company_tier': {'tier': 'faang_plus'},
             },
             {
                 'company': 'Meta',
                 'category': {},
                 'categories': ['data_ml'],
-                'company_tier': {'tier': 'faang-plus'},
+                'company_tier': {'tier': 'faang_plus'},
             },
             {
                 'company': 'Stripe',
@@ -209,7 +209,7 @@ class TestCategoryAndTierCounting:
                 'company': 'Datadog',
                 'category': None,
                 'categories': ['infrastructure_sre'],
-                'company_tier': {'tier': 'public-tech'},
+                'company_tier': {'tier': 'other'},
             },
         ]
 
@@ -229,8 +229,8 @@ class TestCategoryAndTierCounting:
     def test_counts_tiers_correctly(self):
         """Company tiers are counted correctly."""
         jobs = [
-            {'company': 'Google', 'category': {'id': 'software_engineering'}, 'company_tier': {'tier': 'faang-plus'}},
-            {'company': 'Meta', 'category': {'id': 'software_engineering'}, 'company_tier': {'tier': 'faang-plus'}},
+            {'company': 'Google', 'category': {'id': 'software_engineering'}, 'company_tier': {'tier': 'faang_plus'}},
+            {'company': 'Meta', 'category': {'id': 'software_engineering'}, 'company_tier': {'tier': 'faang_plus'}},
             {'company': 'Stripe', 'category': {'id': 'software_engineering'}, 'company_tier': {'tier': 'unicorn'}},
             {'company': 'Unknown Startup', 'category': {'id': 'software_engineering'}, 'company_tier': {'tier': 'other'}},
         ]
@@ -241,14 +241,14 @@ class TestCategoryAndTierCounting:
             data = json.load(f)
 
         tiers = data['snapshots'][0]['tiers']
-        assert tiers['faang-plus'] == 2
+        assert tiers['faang_plus'] == 2
         assert tiers['unicorn'] == 1
         assert tiers['other'] == 1
 
     def test_missing_categories_empty(self):
         """Jobs without category data result in empty category counts."""
         jobs = [
-            {'company': 'Google', 'company_tier': {'tier': 'faang-plus'}},  # no category data
+            {'company': 'Google', 'company_tier': {'tier': 'faang_plus'}},  # no category data
         ]
 
         update_jobs.save_market_history(jobs)
@@ -262,8 +262,8 @@ class TestCategoryAndTierCounting:
     def test_ignores_malformed_category_shapes(self):
         """Malformed category payloads are ignored instead of crashing category counting."""
         jobs = [
-            {'company': 'Google', 'category': {'id': None}, 'company_tier': {'tier': 'faang-plus'}},
-            {'company': 'Meta', 'category': [], 'company_tier': {'tier': 'faang-plus'}},
+            {'company': 'Google', 'category': {'id': None}, 'company_tier': {'tier': 'faang_plus'}},
+            {'company': 'Meta', 'category': [], 'company_tier': {'tier': 'faang_plus'}},
             {'company': 'Stripe', 'categories': 'swe', 'company_tier': {'tier': 'unicorn'}},
         ]
 
@@ -274,6 +274,12 @@ class TestCategoryAndTierCounting:
 
         categories = data['snapshots'][0]['categories']
         assert categories == {}
+
+    def test_iter_category_ids_ignores_non_dict_job(self):
+        """Non-dict job payloads are skipped without raising AttributeError."""
+        assert list(update_jobs.iter_category_ids(None)) == []
+        assert list(update_jobs.iter_category_ids("not a job")) == []
+        assert list(update_jobs.iter_category_ids(['software_engineering'])) == []
 
     def test_missing_tier_defaults_to_other(self):
         """Jobs without tier default to 'other'."""
@@ -331,11 +337,11 @@ class TestTopCompanies:
     def test_top_companies_sorted_by_count(self):
         """Top companies are sorted by job count descending."""
         jobs = [
-            {'company': 'Google', 'categories': ['swe'], 'company_tier': {'tier': 'faang-plus'}},
-            {'company': 'Google', 'categories': ['ml'], 'company_tier': {'tier': 'faang-plus'}},
-            {'company': 'Google', 'categories': ['data'], 'company_tier': {'tier': 'faang-plus'}},
-            {'company': 'Meta', 'categories': ['swe'], 'company_tier': {'tier': 'faang-plus'}},
-            {'company': 'Meta', 'categories': ['ml'], 'company_tier': {'tier': 'faang-plus'}},
+            {'company': 'Google', 'categories': ['swe'], 'company_tier': {'tier': 'faang_plus'}},
+            {'company': 'Google', 'categories': ['ml'], 'company_tier': {'tier': 'faang_plus'}},
+            {'company': 'Google', 'categories': ['data'], 'company_tier': {'tier': 'faang_plus'}},
+            {'company': 'Meta', 'categories': ['swe'], 'company_tier': {'tier': 'faang_plus'}},
+            {'company': 'Meta', 'categories': ['ml'], 'company_tier': {'tier': 'faang_plus'}},
             {'company': 'Stripe', 'categories': ['swe'], 'company_tier': {'tier': 'unicorn'}},
         ]
 
@@ -353,9 +359,9 @@ class TestTopCompanies:
     def test_unique_companies_count(self):
         """Unique companies count is accurate."""
         jobs = [
-            {'company': 'Google', 'categories': ['swe'], 'company_tier': {'tier': 'faang-plus'}},
-            {'company': 'Google', 'categories': ['ml'], 'company_tier': {'tier': 'faang-plus'}},
-            {'company': 'Meta', 'categories': ['swe'], 'company_tier': {'tier': 'faang-plus'}},
+            {'company': 'Google', 'categories': ['swe'], 'company_tier': {'tier': 'faang_plus'}},
+            {'company': 'Google', 'categories': ['ml'], 'company_tier': {'tier': 'faang_plus'}},
+            {'company': 'Meta', 'categories': ['swe'], 'company_tier': {'tier': 'faang_plus'}},
             {'company': 'Stripe', 'categories': ['data'], 'company_tier': {'tier': 'unicorn'}},
         ]
 
@@ -370,9 +376,9 @@ class TestTopCompanies:
     def test_avg_jobs_per_company_calculation(self):
         """Average jobs per company is calculated correctly."""
         jobs = [
-            {'company': 'Google', 'categories': ['swe'], 'company_tier': {'tier': 'faang-plus'}},
-            {'company': 'Google', 'categories': ['ml'], 'company_tier': {'tier': 'faang-plus'}},
-            {'company': 'Meta', 'categories': ['swe'], 'company_tier': {'tier': 'faang-plus'}},
+            {'company': 'Google', 'categories': ['swe'], 'company_tier': {'tier': 'faang_plus'}},
+            {'company': 'Google', 'categories': ['ml'], 'company_tier': {'tier': 'faang_plus'}},
+            {'company': 'Meta', 'categories': ['swe'], 'company_tier': {'tier': 'faang_plus'}},
             {'company': 'Stripe', 'categories': ['data'], 'company_tier': {'tier': 'unicorn'}},
         ]
 
@@ -443,7 +449,7 @@ class TestHistoryRetention:
         with open(self.history_path, 'w', encoding='utf-8') as f:
             json.dump(old_history, f)
 
-        jobs = [{'company': 'Google', 'categories': ['swe'], 'company_tier': {'tier': 'faang-plus'}}]
+        jobs = [{'company': 'Google', 'categories': ['swe'], 'company_tier': {'tier': 'faang_plus'}}]
         update_jobs.save_market_history(jobs)
 
         with open(self.history_path, encoding='utf-8') as f:
@@ -457,13 +463,13 @@ class TestHistoryRetention:
     def test_updates_existing_snapshot_for_today(self):
         """If today's snapshot exists, it is updated rather than duplicated."""
         # First call
-        jobs_v1 = [{'company': 'Google', 'categories': ['swe'], 'company_tier': {'tier': 'faang-plus'}}]
+        jobs_v1 = [{'company': 'Google', 'categories': ['swe'], 'company_tier': {'tier': 'faang_plus'}}]
         update_jobs.save_market_history(jobs_v1)
 
         # Second call on same day with different data
         jobs_v2 = [
-            {'company': 'Google', 'categories': ['swe'], 'company_tier': {'tier': 'faang-plus'}},
-            {'company': 'Meta', 'categories': ['ml'], 'company_tier': {'tier': 'faang-plus'}},
+            {'company': 'Google', 'categories': ['swe'], 'company_tier': {'tier': 'faang_plus'}},
+            {'company': 'Meta', 'categories': ['ml'], 'company_tier': {'tier': 'faang_plus'}},
         ]
         update_jobs.save_market_history(jobs_v2)
 
@@ -520,7 +526,7 @@ class TestHistoryRetention:
         with open(self.history_path, 'w', encoding='utf-8') as f:
             json.dump(old_history, f)
 
-        jobs = [{'company': 'Google', 'categories': ['swe'], 'company_tier': {'tier': 'faang-plus'}}]
+        jobs = [{'company': 'Google', 'categories': ['swe'], 'company_tier': {'tier': 'faang_plus'}}]
         update_jobs.save_market_history(jobs)
 
         with open(self.history_path, encoding='utf-8') as f:
@@ -558,7 +564,7 @@ class TestFileHandling:
         if os.path.exists(self.temp_dir):
             shutil.rmtree(self.temp_dir)
 
-        jobs = [{'company': 'Google', 'categories': ['swe'], 'company_tier': {'tier': 'faang-plus'}}]
+        jobs = [{'company': 'Google', 'categories': ['swe'], 'company_tier': {'tier': 'faang_plus'}}]
         update_jobs.save_market_history(jobs)
 
         assert os.path.exists(self.history_path)
@@ -569,7 +575,7 @@ class TestFileHandling:
         with open(self.history_path, 'w', encoding='utf-8') as f:
             f.write("{invalid json")
 
-        jobs = [{'company': 'Google', 'categories': ['swe'], 'company_tier': {'tier': 'faang-plus'}}]
+        jobs = [{'company': 'Google', 'categories': ['swe'], 'company_tier': {'tier': 'faang_plus'}}]
         update_jobs.save_market_history(jobs)
 
         # Should recover and create new history
@@ -696,7 +702,7 @@ class TestSaveMarketHistoryDeterminism:
 
         with patch("update_jobs.os.path.join", side_effect=patched_join):
             update_jobs.save_market_history(
-                [{"company": "Google", "categories": ["swe"], "company_tier": {"tier": "faang-plus"}}]
+                [{"company": "Google", "categories": ["swe"], "company_tier": {"tier": "faang_plus"}}]
             )
 
         with open(history_path, "r", encoding="utf-8") as f:
@@ -712,8 +718,8 @@ class TestSaveMarketHistoryDeterminism:
         monkeypatch.setattr(update_jobs, "datetime", self._fixed_datetime_class(self.FIXED_NOW))
 
         jobs = [
-            {"company": "Google", "categories": ["swe", "ml"], "company_tier": {"tier": "faang-plus"}},
-            {"company": "Meta", "categories": ["swe"], "company_tier": {"tier": "faang-plus"}},
+            {"company": "Google", "categories": ["swe", "ml"], "company_tier": {"tier": "faang_plus"}},
+            {"company": "Meta", "categories": ["swe"], "company_tier": {"tier": "faang_plus"}},
             {"company": "Stripe", "categories": ["data"], "company_tier": {"tier": "unicorn"}},
         ]
 
@@ -741,4 +747,4 @@ class TestSaveMarketHistoryDeterminism:
         assert snapshot["date"] == "2026-04-03"
         assert snapshot["timestamp"] == self.FIXED_NOW.isoformat()
         assert snapshot["categories"] == {"swe": 2, "ml": 1, "data": 1}
-        assert snapshot["tiers"] == {"faang-plus": 2, "unicorn": 1}
+        assert snapshot["tiers"] == {"faang_plus": 2, "unicorn": 1}

--- a/tests/test_save_market_history.py
+++ b/tests/test_save_market_history.py
@@ -55,7 +55,7 @@ class TestSaveMarketHistoryStructure:
         update_jobs.save_market_history(jobs)
 
         assert os.path.exists(self.history_path)
-        with open(self.history_path, 'r', encoding='utf-8') as f:
+        with open(self.history_path, encoding='utf-8') as f:
             data = json.load(f)
 
         assert 'meta' in data
@@ -77,7 +77,7 @@ class TestSaveMarketHistoryStructure:
         jobs = [{'company': 'Stripe', 'categories': ['swe'], 'company_tier': {'tier': 'unicorn'}}]
         update_jobs.save_market_history(jobs)
 
-        with open(self.history_path, 'r', encoding='utf-8') as f:
+        with open(self.history_path, encoding='utf-8') as f:
             data = json.load(f)
 
         meta = data['meta']
@@ -93,7 +93,7 @@ class TestSaveMarketHistoryStructure:
         jobs = [{'company': 'Meta', 'categories': ['ml'], 'company_tier': {'tier': 'faang-plus'}}]
         update_jobs.save_market_history(jobs)
 
-        with open(self.history_path, 'r', encoding='utf-8') as f:
+        with open(self.history_path, encoding='utf-8') as f:
             data = json.load(f)
 
         snapshot_date = data['snapshots'][0]['date']
@@ -125,8 +125,49 @@ class TestCategoryAndTierCounting:
         if os.path.exists(self.temp_dir):
             shutil.rmtree(self.temp_dir)
 
-    def test_counts_categories_correctly(self):
-        """Categories are counted across all jobs."""
+    def test_counts_categories_correctly_from_singular_category_field(self):
+        """Categories are counted from the enriched singular category field."""
+        jobs = [
+            {'company': 'Google', 'category': {'id': 'software_engineering'}, 'company_tier': {'tier': 'faang-plus'}},
+            {'company': 'Meta', 'category': {'id': 'software_engineering'}, 'company_tier': {'tier': 'faang-plus'}},
+            {'company': 'Stripe', 'category': {'id': 'data_ml'}, 'company_tier': {'tier': 'unicorn'}},
+        ]
+
+        update_jobs.save_market_history(jobs)
+
+        with open(self.history_path, encoding='utf-8') as f:
+            data = json.load(f)
+
+        categories = data['snapshots'][0]['categories']
+        assert categories == {'software_engineering': 2, 'data_ml': 1}
+
+    def test_prefers_singular_category_field_over_legacy_categories_list(self):
+        """Regression guard: enriched jobs should not double-count legacy categories lists."""
+        jobs = [
+            {
+                'company': 'Google',
+                'category': {'id': 'software_engineering'},
+                'categories': ['data_ml', 'product'],
+                'company_tier': {'tier': 'faang-plus'},
+            },
+            {
+                'company': 'Stripe',
+                'category': {'id': 'data_ml'},
+                'categories': ['software_engineering'],
+                'company_tier': {'tier': 'unicorn'},
+            },
+        ]
+
+        update_jobs.save_market_history(jobs)
+
+        with open(self.history_path, encoding='utf-8') as f:
+            data = json.load(f)
+
+        categories = data['snapshots'][0]['categories']
+        assert categories == {'software_engineering': 1, 'data_ml': 1}
+
+    def test_falls_back_to_legacy_categories_list_when_category_missing(self):
+        """Legacy category lists still count when enriched category data is absent."""
         jobs = [
             {'company': 'Google', 'categories': ['swe', 'ml'], 'company_tier': {'tier': 'faang-plus'}},
             {'company': 'Meta', 'categories': ['swe'], 'company_tier': {'tier': 'faang-plus'}},
@@ -135,7 +176,7 @@ class TestCategoryAndTierCounting:
 
         update_jobs.save_market_history(jobs)
 
-        with open(self.history_path, 'r', encoding='utf-8') as f:
+        with open(self.history_path, encoding='utf-8') as f:
             data = json.load(f)
 
         categories = data['snapshots'][0]['categories']
@@ -143,18 +184,60 @@ class TestCategoryAndTierCounting:
         assert categories['ml'] == 1
         assert categories['data'] == 1
 
-    def test_counts_tiers_correctly(self):
-        """Company tiers are counted correctly."""
+    def test_falls_back_to_legacy_categories_when_category_payload_is_invalid(self):
+        """Legacy category lists still count when enriched category payloads are invalid."""
         jobs = [
-            {'company': 'Google', 'categories': ['swe'], 'company_tier': {'tier': 'faang-plus'}},
-            {'company': 'Meta', 'categories': ['swe'], 'company_tier': {'tier': 'faang-plus'}},
-            {'company': 'Stripe', 'categories': ['swe'], 'company_tier': {'tier': 'unicorn'}},
-            {'company': 'Unknown Startup', 'categories': ['swe'], 'company_tier': {'tier': 'other'}},
+            {
+                'company': 'Google',
+                'category': {'id': None},
+                'categories': ['swe'],
+                'company_tier': {'tier': 'faang-plus'},
+            },
+            {
+                'company': 'Meta',
+                'category': {},
+                'categories': ['data_ml'],
+                'company_tier': {'tier': 'faang-plus'},
+            },
+            {
+                'company': 'Stripe',
+                'category': {'id': ''},
+                'categories': ['product'],
+                'company_tier': {'tier': 'unicorn'},
+            },
+            {
+                'company': 'Datadog',
+                'category': None,
+                'categories': ['infrastructure_sre'],
+                'company_tier': {'tier': 'public-tech'},
+            },
         ]
 
         update_jobs.save_market_history(jobs)
 
-        with open(self.history_path, 'r', encoding='utf-8') as f:
+        with open(self.history_path, encoding='utf-8') as f:
+            data = json.load(f)
+
+        categories = data['snapshots'][0]['categories']
+        assert categories == {
+            'swe': 1,
+            'data_ml': 1,
+            'product': 1,
+            'infrastructure_sre': 1,
+        }
+
+    def test_counts_tiers_correctly(self):
+        """Company tiers are counted correctly."""
+        jobs = [
+            {'company': 'Google', 'category': {'id': 'software_engineering'}, 'company_tier': {'tier': 'faang-plus'}},
+            {'company': 'Meta', 'category': {'id': 'software_engineering'}, 'company_tier': {'tier': 'faang-plus'}},
+            {'company': 'Stripe', 'category': {'id': 'software_engineering'}, 'company_tier': {'tier': 'unicorn'}},
+            {'company': 'Unknown Startup', 'category': {'id': 'software_engineering'}, 'company_tier': {'tier': 'other'}},
+        ]
+
+        update_jobs.save_market_history(jobs)
+
+        with open(self.history_path, encoding='utf-8') as f:
             data = json.load(f)
 
         tiers = data['snapshots'][0]['tiers']
@@ -163,14 +246,30 @@ class TestCategoryAndTierCounting:
         assert tiers['other'] == 1
 
     def test_missing_categories_empty(self):
-        """Jobs without categories field result in empty category counts."""
+        """Jobs without category data result in empty category counts."""
         jobs = [
-            {'company': 'Google', 'company_tier': {'tier': 'faang-plus'}},  # no categories
+            {'company': 'Google', 'company_tier': {'tier': 'faang-plus'}},  # no category data
         ]
 
         update_jobs.save_market_history(jobs)
 
-        with open(self.history_path, 'r', encoding='utf-8') as f:
+        with open(self.history_path, encoding='utf-8') as f:
+            data = json.load(f)
+
+        categories = data['snapshots'][0]['categories']
+        assert categories == {}
+
+    def test_ignores_malformed_category_shapes(self):
+        """Malformed category payloads are ignored instead of crashing category counting."""
+        jobs = [
+            {'company': 'Google', 'category': {'id': None}, 'company_tier': {'tier': 'faang-plus'}},
+            {'company': 'Meta', 'category': [], 'company_tier': {'tier': 'faang-plus'}},
+            {'company': 'Stripe', 'categories': 'swe', 'company_tier': {'tier': 'unicorn'}},
+        ]
+
+        update_jobs.save_market_history(jobs)
+
+        with open(self.history_path, encoding='utf-8') as f:
             data = json.load(f)
 
         categories = data['snapshots'][0]['categories']
@@ -185,7 +284,7 @@ class TestCategoryAndTierCounting:
 
         update_jobs.save_market_history(jobs)
 
-        with open(self.history_path, 'r', encoding='utf-8') as f:
+        with open(self.history_path, encoding='utf-8') as f:
             data = json.load(f)
 
         tiers = data['snapshots'][0]['tiers']
@@ -223,7 +322,7 @@ class TestTopCompanies:
 
         update_jobs.save_market_history(jobs)
 
-        with open(self.history_path, 'r', encoding='utf-8') as f:
+        with open(self.history_path, encoding='utf-8') as f:
             data = json.load(f)
 
         top_companies = data['snapshots'][0]['top_companies']
@@ -242,7 +341,7 @@ class TestTopCompanies:
 
         update_jobs.save_market_history(jobs)
 
-        with open(self.history_path, 'r', encoding='utf-8') as f:
+        with open(self.history_path, encoding='utf-8') as f:
             data = json.load(f)
 
         top_companies = data['snapshots'][0]['top_companies']
@@ -262,7 +361,7 @@ class TestTopCompanies:
 
         update_jobs.save_market_history(jobs)
 
-        with open(self.history_path, 'r', encoding='utf-8') as f:
+        with open(self.history_path, encoding='utf-8') as f:
             data = json.load(f)
 
         unique_companies = data['snapshots'][0]['unique_companies']
@@ -279,7 +378,7 @@ class TestTopCompanies:
 
         update_jobs.save_market_history(jobs)
 
-        with open(self.history_path, 'r', encoding='utf-8') as f:
+        with open(self.history_path, encoding='utf-8') as f:
             data = json.load(f)
 
         avg_jobs = data['snapshots'][0]['avg_jobs_per_company']
@@ -347,7 +446,7 @@ class TestHistoryRetention:
         jobs = [{'company': 'Google', 'categories': ['swe'], 'company_tier': {'tier': 'faang-plus'}}]
         update_jobs.save_market_history(jobs)
 
-        with open(self.history_path, 'r', encoding='utf-8') as f:
+        with open(self.history_path, encoding='utf-8') as f:
             data = json.load(f)
 
         # Should have removed the 100-day-old snapshot
@@ -368,7 +467,7 @@ class TestHistoryRetention:
         ]
         update_jobs.save_market_history(jobs_v2)
 
-        with open(self.history_path, 'r', encoding='utf-8') as f:
+        with open(self.history_path, encoding='utf-8') as f:
             data = json.load(f)
 
         # Should have only one snapshot with updated data
@@ -424,7 +523,7 @@ class TestHistoryRetention:
         jobs = [{'company': 'Google', 'categories': ['swe'], 'company_tier': {'tier': 'faang-plus'}}]
         update_jobs.save_market_history(jobs)
 
-        with open(self.history_path, 'r', encoding='utf-8') as f:
+        with open(self.history_path, encoding='utf-8') as f:
             data = json.load(f)
 
         dates = [s['date'] for s in data['snapshots']]
@@ -474,7 +573,7 @@ class TestFileHandling:
         update_jobs.save_market_history(jobs)
 
         # Should recover and create new history
-        with open(self.history_path, 'r', encoding='utf-8') as f:
+        with open(self.history_path, encoding='utf-8') as f:
             data = json.load(f)
 
         assert len(data['snapshots']) == 1
@@ -486,7 +585,7 @@ class TestFileHandling:
         jobs = []
         update_jobs.save_market_history(jobs)
 
-        with open(self.history_path, 'r', encoding='utf-8') as f:
+        with open(self.history_path, encoding='utf-8') as f:
             data = json.load(f)
 
         snapshot = data['snapshots'][0]
@@ -505,7 +604,7 @@ class TestFileHandling:
 
         update_jobs.save_market_history(jobs)
 
-        with open(self.history_path, 'r', encoding='utf-8') as f:
+        with open(self.history_path, encoding='utf-8') as f:
             data = json.load(f)
 
         top_companies = data['snapshots'][0]['top_companies']
@@ -525,7 +624,7 @@ class TestFileHandling:
 
         update_jobs.save_market_history(jobs)
 
-        with open(self.history_path, 'r', encoding='utf-8') as f:
+        with open(self.history_path, encoding='utf-8') as f:
             data = json.load(f)
 
         snapshot = data['snapshots'][0]


### PR DESCRIPTION
## Why

`docs/market-history.json` has been silently empty-on-categories for the entire 90-day retention window. The aggregation step in `save_market_history()` reads the wrong key.

`scripts/update_jobs.py` (pre-fix):
```python
for job in jobs:
    for category in job.get('categories', []):   # plural list, never populated post-enrichment
        category_counts[category] += 1
```

But `enrich_jobs()` writes the singular form and never creates a `categories` list:
```python
category = categorize_job(title, description)
job['category'] = category    # {'id': 'software_engineering', 'name': ..., 'emoji': ...}
```

Reproduced against the live artifact:
```
$ python3 -c "import json; d=json.load(open('docs/market-history.json')); \
  [print(s['date'], 'cats=', len(s['categories'])) for s in d['snapshots'][-5:]]"
2026-05-22 cats= 0
2026-05-23 cats= 0
2026-05-24 cats= 0
2026-05-25 cats= 0
2026-05-26 cats= 0
```

All 81 retained snapshots show `categories: {}`. The category breakdown that feeds any "growing/declining categories" analytic has been dead.

## What

New module-level helper `iter_category_ids(job)` (`scripts/update_jobs.py:2464`):

- Reads from `category.id` first (the enriched shape).
- Falls back to the legacy `categories` list **only** when the singular path is absent or invalid — handles `None`, `{}`, `{'id': None}`, `{'id': ''}`, non-list `categories` values, and non-string elements.
- Strips whitespace and skips empty values so malformed upstream data can't poison the Counter.

`save_market_history()` switches to the new helper.

## Tests

`tests/test_save_market_history.py` adds four targeted regressions:

- `test_counts_categories_correctly_from_singular_category_field` — the path that's broken on main today.
- `test_prefers_singular_category_field_over_legacy_categories_list` — guards against double-counting if both shapes coexist.
- `test_falls_back_to_legacy_categories_list_when_category_missing` — keeps old fixtures working.
- `test_falls_back_to_legacy_categories_when_category_payload_is_invalid` — partial-scrape recovery against four invalid singular shapes.

Existing snapshot-schema / retention / determinism assertions stay green.

## Validation

- `pytest tests/test_save_market_history.py`: 25 passed.
- `pytest` (full suite): 722 passed.
- `pre-commit run --all-files`: clean.
- End-to-end smoke (run real `enrich_jobs()` → `save_market_history()` on synthetic raw jobs, inspect resulting `docs/market-history.json`):
  ```
  before fix: categories: {}
  after  fix: categories: {'software_engineering': 2, 'data_ml': 2}
  ```
  Counts equal the enriched job count, as expected.

## Provenance

This is the same scoped fix from #274 (closed without merge despite green CI), rebased cleanly onto current `main`. Original work by @rvac-bucky — author attribution preserved in the commit. The `docs/predictions.json` conflict from #274 doesn't re-occur because #298 already landed the trailing-newline normalization.

Closes #228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved job category data normalization to support both legacy and enriched data formats, enhancing system robustness and backward compatibility.

* **Tests**
  * Updated test suite to validate consistent category data handling and standardized tier naming conventions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ambicuity/New-Grad-Jobs/pull/299?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->