### PR TITLE
fix(ui): bump LIVE-chip staleness threshold from 15 min to 24 h

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -59,15 +59,15 @@
   </div>
 
   <!-- Pure-JS helper for the LIVE chip, loadable in Node for unit testing. -->
-  <script src="terminal/live-stamp-format.js?v=8"></script>
+  <script src="terminal/live-stamp-format.js?v=9"></script>
 
   <!-- Cache-bust the bundle when its shape changes. Bump v= on data-shape edits. -->
-  <script type="text/babel" src="terminal/data.jsx?v=8"></script>
-  <script type="text/babel" src="terminal/contributors-data.jsx?v=8"></script>
-  <script type="text/babel" src="terminal/dashboard.jsx?v=8"></script>
-  <script type="text/babel" src="terminal/contributors.jsx?v=8"></script>
-  <script type="text/babel" src="terminal/live-stamp.jsx?v=8"></script>
-  <script type="text/babel" src="terminal/app.jsx?v=8"></script>
+  <script type="text/babel" src="terminal/data.jsx?v=9"></script>
+  <script type="text/babel" src="terminal/contributors-data.jsx?v=9"></script>
+  <script type="text/babel" src="terminal/dashboard.jsx?v=9"></script>
+  <script type="text/babel" src="terminal/contributors.jsx?v=9"></script>
+  <script type="text/babel" src="terminal/live-stamp.jsx?v=9"></script>
+  <script type="text/babel" src="terminal/app.jsx?v=9"></script>
 
   <script type="text/babel">
     (async () => {

--- a/docs/terminal/live-stamp-format.js
+++ b/docs/terminal/live-stamp-format.js
@@ -4,10 +4,17 @@
 // Exposes on window: formatLiveStamp, liveStampState
 // In Node: exported via module.exports.
 (function (global) {
-  // The scraper runs every 5 min on schedule. If we haven't seen a fresh
-  // generated_at within this window, the pipeline is failing or the page
-  // is offline. STALE_MS = 15 min gives 2 missed cycles of headroom.
-  var STALE_MS = 15 * 60 * 1000;
+  // The scraper is scheduled every 5 min, but GitHub Actions cron is best-
+  // effort: scheduled runs land 10-30+ min late on free-tier load, runs that
+  // overlap an in-flight one are cancelled by the workflow's concurrency
+  // group, and `*/5` schedules are deprioritized vs. larger intervals.
+  // Effective cadence is 15-60 min, with occasional multi-hour gaps.
+  //
+  // The chip is meant to warn that the pipeline is genuinely broken, not
+  // flap on normal cron jitter. 24 h gives a full day of tolerance for
+  // queue starvation and platform incidents while still alerting if the
+  // scraper has been completely down for a day.
+  var STALE_MS = 24 * 60 * 60 * 1000;
 
   function liveStampState(isoString, now) {
     if (!isoString) return { kind: 'offline' };

--- a/tests/terminal/test_live_stamp.cjs
+++ b/tests/terminal/test_live_stamp.cjs
@@ -36,8 +36,8 @@ function run(name, fn) {
   }
 }
 
-run('STALE_MS is 15 minutes', () => {
-  assert.strictEqual(STALE_MS, 15 * 60 * 1000);
+run('STALE_MS is 24 hours', () => {
+  assert.strictEqual(STALE_MS, 24 * 60 * 60 * 1000);
 });
 
 run('returns LIVE when generated_at is fresh', () => {
@@ -48,15 +48,27 @@ run('returns LIVE when generated_at is fresh', () => {
   assert.ok(stamp.text && stamp.text.length > 0);
 });
 
-run('returns STALE after 16 minutes', () => {
-  const now = new Date('2026-05-16T21:48:00Z');
+run('still LIVE after 1 hour (well within the 24 h tolerance)', () => {
+  const now = new Date('2026-05-16T22:32:00Z');
+  const stamp = formatLiveStamp('2026-05-16T21:32:00Z', now);
+  assert.strictEqual(stamp.label, 'LIVE');
+});
+
+run('still LIVE after 12 hours', () => {
+  const now = new Date('2026-05-17T09:32:00Z');
+  const stamp = formatLiveStamp('2026-05-16T21:32:00Z', now);
+  assert.strictEqual(stamp.label, 'LIVE');
+});
+
+run('returns STALE after 25 hours (past the 24 h threshold)', () => {
+  const now = new Date('2026-05-17T22:32:00Z');
   const stamp = formatLiveStamp('2026-05-16T21:32:00Z', now);
   assert.strictEqual(stamp.label, 'STALE');
   assert.strictEqual(stamp.dot, '#e0a23a');
 });
 
-run('returns LIVE right at the boundary (14:59 ago)', () => {
-  const now = new Date(Date.parse('2026-05-16T21:32:00Z') + (15 * 60 * 1000 - 1));
+run('returns LIVE right at the boundary (1 ms before 24 h)', () => {
+  const now = new Date(Date.parse('2026-05-16T21:32:00Z') + (24 * 60 * 60 * 1000 - 1));
   const stamp = formatLiveStamp('2026-05-16T21:32:00Z', now);
   assert.strictEqual(stamp.label, 'LIVE');
 });
@@ -80,6 +92,12 @@ run('liveStampState exposes age and parsed time', () => {
   assert.strictEqual(state.kind, 'live');
   assert.strictEqual(state.ageMs, 3 * 60 * 1000);
   assert.strictEqual(state.when.toISOString(), '2026-05-16T21:32:00.000Z');
+});
+
+run('liveStampState flips to stale once past 24 h', () => {
+  const now = new Date(Date.parse('2026-05-16T21:32:00Z') + 24 * 60 * 60 * 1000 + 1000);
+  const state = liveStampState('2026-05-16T21:32:00Z', now);
+  assert.strictEqual(state.kind, 'stale');
 });
 
 run('does not crash if Intl throws (text falls back to ISO)', () => {


### PR DESCRIPTION
## Why

The LIVE/STALE/OFFLINE chip in the terminal top bar has been reading **STALE** for the vast majority of the day even though the scraping pipeline is healthy. Visitors land on jobs.riteshrana.engineer and see a perpetually-amber chip suggesting the data is broken.

The chip's threshold was calibrated against the workflow's aspirational cadence, not the cadence GitHub Actions actually delivers.

### Root cause

- `update-jobs.yml` cron is `*/5 * * * *` — designed for a 5-min refresh.
- `STALE_MS` was set to **15 min** = 2 missed cycles of headroom.
- In practice on GitHub free tier:
  - Each scrape run takes ~5 min (last 15 runs averaged 4m24s–5m22s).
  - Scheduled runs land 10–30+ min late under platform load.
  - `concurrency.cancel-in-progress: true` kills queued runs when one is in flight.
  - GitHub explicitly deprioritizes `*/5` schedules.
- **Real cadence on `origin/main`** (last 6 scheduled `🤖 Update job listings` commits):
  ```
  18:47, 17:47, 17:27, 17:01, 14:29, 12:42
      └─60m─┘    └─26m─┘  └─152m gap─┘   ← 2.5-hour drought
  ```
- Net effect: the chip flaps on normal cron jitter instead of warning about real outages.

## What

Raise `STALE_MS` from `15 * 60 * 1000` to `24 * 60 * 60 * 1000` in `docs/terminal/live-stamp-format.js`. The chip is meant to signal *"the pipeline is broken"*, not *"a cron fired late"*. 24 h gives a full day of tolerance for queue starvation and platform incidents while still alerting if scraping has been completely down.

Updated tests:
- `STALE_MS is 24 hours` (was 15 minutes)
- New: `still LIVE after 1 hour`, `still LIVE after 12 hours`
- `returns STALE after 25 hours` (renamed/repurposed from `after 16 minutes`)
- Boundary case now anchored to 1 ms before 24 h
- Added: `liveStampState flips to stale once past 24 h`

Bumped cache-bust `?v=8` → `?v=9` across `docs/index.html` so existing visitors immediately fetch the new chip.

## Validation

```
$ node tests/terminal/test_live_stamp.cjs
  ok  STALE_MS is 24 hours
  ok  returns LIVE when generated_at is fresh
  ok  still LIVE after 1 hour (well within the 24 h tolerance)
  ok  still LIVE after 12 hours
  ok  returns STALE after 25 hours (past the 24 h threshold)
  ok  returns LIVE right at the boundary (1 ms before 24 h)
  ok  returns OFFLINE for null/undefined generated_at
  ok  returns OFFLINE for non-parseable string
  ok  liveStampState exposes age and parsed time
  ok  liveStampState flips to stale once past 24 h
  ok  does not crash if Intl throws (text falls back to ISO)
all live-stamp tests passed
```

End-to-end smoke against the current real `docs/jobs.json` (56.8 min old — would have read STALE before this change):

```
generated_at: 2026-05-26T18:47:52.487620+00:00
now         : 2026-05-26T19:44:38.215Z
age (min)   : 56.8
chip label  : LIVE      ← was STALE before
chip color  : #5fd28a
chip text   : May 26, 2026, 13:47 CDT
```

## Notes

This does not change the underlying scrape cadence — the workflow still tries to refresh every 5 min. It only realigns the *indicator's* threshold with reality, so the chip stops crying wolf. If scraping is ever down for a full day, the chip will (correctly) flip to STALE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended LIVE indicator staleness threshold from 15 minutes to 24 hours. Live content will now remain marked as LIVE for extended periods before transitioning to STALE status.

* **Chores**
  * Updated cache-busting configuration for JavaScript bundles across terminal, dashboard, and application components to ensure fresh asset delivery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ambicuity/New-Grad-Jobs/pull/303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->