### PR TITLE
fix(docs): auto-sync README 'Last updated' stamp from jobs.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1201,4 +1201,4 @@ Found a job we're missing? Want to report a closed position?
 
 ⭐ **Star this repo** to stay updated with the latest new grad opportunities!
 
-*Last updated: 2026-03-12 05:46:03 UTC*
+*Last updated: 2026-05-26 19:52:33 UTC*

--- a/scripts/sync_readme_counts.py
+++ b/scripts/sync_readme_counts.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python3
-"""Sync the README job-count tokens to match docs/jobs.json.
+"""Sync the README job-count tokens and "Last updated" stamp to match docs/jobs.json.
 
-README.md is a human-maintained document; the only piece of it the automated
-pipeline owns is the set of count tokens marked by HTML comments:
+README.md is a human-maintained document; the pieces the automated pipeline
+owns are:
 
-    <!-- COUNT:<id> -->42<!-- /COUNT -->
+  1. Count tokens marked by HTML comments:
+         <!-- COUNT:<id> -->42<!-- /COUNT -->
+     Only the digits between the two markers are ever rewritten.
 
-Only the digits between the two markers are ever rewritten — no line is added,
-removed, or reordered. Job tables, prose, and badges are untouched.
+  2. The trailing "Last updated" line at the bottom of the file:
+         *Last updated: YYYY-MM-DD HH:MM:SS UTC*
+     The timestamp is rewritten from `meta.generated_at` in docs/jobs.json so
+     it advances on every scrape rather than rotting until someone edits it by
+     hand. The surrounding line, prose, and tables are untouched.
 
 This is invoked from scripts/update_jobs.py after each scrape; it is also safe
 to run by hand from the repo root::
@@ -21,12 +26,20 @@ import json
 import pathlib
 import re
 import sys
-from typing import Dict, Mapping
+from datetime import datetime, timezone
+from typing import Dict, Mapping, Optional
 
 # The marker regex. Strict: only ASCII digits between markers; id is
 # [a-z_], so "total" and category ids like "software_engineering" match.
 COUNT_TOKEN_RE = re.compile(
     r"<!--\s*COUNT:(?P<id>[a-z_]+)\s*-->(?P<value>\d+)<!--\s*/COUNT\s*-->"
+)
+
+# The trailing "*Last updated: ... UTC*" line. Anchored to the line itself
+# (italic, prefix "Last updated:", suffix "UTC"), tolerant of whitespace
+# and any non-asterisk timestamp content the prior script or a human wrote.
+LAST_UPDATED_RE = re.compile(
+    r"\*Last updated:\s*[^*]*?UTC\*"
 )
 
 
@@ -41,6 +54,50 @@ def read_counts_from_jobs_json(jobs_path: pathlib.Path) -> Dict[str, int]:
         if cid:
             counts[cid] = int(cat.get("count", 0))
     return counts
+
+
+def read_generated_at_from_jobs_json(jobs_path: pathlib.Path) -> Optional[datetime]:
+    """Return the parsed `meta.generated_at` as a UTC datetime, or None if absent/invalid."""
+    with open(jobs_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    raw = (data.get("meta") or {}).get("generated_at")
+    if not raw or not isinstance(raw, str):
+        return None
+    try:
+        # fromisoformat handles "+00:00" offsets and trailing microseconds; the
+        # legacy "Z" suffix is handled by replacing with the explicit offset.
+        ts = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ts.astimezone(timezone.utc)
+
+
+def format_last_updated(ts: datetime) -> str:
+    """Format a UTC datetime as the canonical README "Last updated" stamp."""
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    ts = ts.astimezone(timezone.utc)
+    return f"*Last updated: {ts.strftime('%Y-%m-%d %H:%M:%S')} UTC*"
+
+
+def apply_last_updated_to_readme(readme_text: str, ts: Optional[datetime]) -> str:
+    """Rewrite the trailing "*Last updated: ... UTC*" line in README.
+
+    No-op if:
+      * `ts` is None (jobs.json had no parseable generated_at), or
+      * README has no recognisable "Last updated: ... UTC" line.
+
+    The marker is intentionally absent from this contract — the line itself is
+    its own marker. This keeps the README readable for humans skimming the
+    bottom of the file.
+    """
+    if ts is None:
+        return readme_text
+    if not LAST_UPDATED_RE.search(readme_text):
+        return readme_text
+    return LAST_UPDATED_RE.sub(format_last_updated(ts), readme_text, count=1)
 
 
 def apply_counts_to_readme(readme_text: str, counts: Mapping[str, int]) -> str:
@@ -70,7 +127,11 @@ def apply_counts_to_readme(readme_text: str, counts: Mapping[str, int]) -> str:
 
 
 def sync_readme_counts(repo_root: pathlib.Path) -> bool:
-    """Update README.md in place from docs/jobs.json. Returns True if changed."""
+    """Update README.md in place from docs/jobs.json. Returns True if changed.
+
+    Rewrites both the COUNT-marker tokens and the trailing "Last updated" line.
+    A no-op `apply_*` call (no markers found, or already in sync) is safe.
+    """
     repo_root = pathlib.Path(repo_root)
     readme_path = repo_root / "README.md"
     jobs_path = repo_root / "docs" / "jobs.json"
@@ -80,8 +141,11 @@ def sync_readme_counts(repo_root: pathlib.Path) -> bool:
         return False
 
     counts = read_counts_from_jobs_json(jobs_path)
+    generated_at = read_generated_at_from_jobs_json(jobs_path)
+
     original = readme_path.read_text(encoding="utf-8")
     updated = apply_counts_to_readme(original, counts)
+    updated = apply_last_updated_to_readme(updated, generated_at)
 
     if updated == original:
         return False

--- a/tests/test_readme_sync.py
+++ b/tests/test_readme_sync.py
@@ -17,10 +17,16 @@ import re
 
 import pytest
 
+from datetime import datetime, timezone, timedelta
+
 from sync_readme_counts import (
     COUNT_TOKEN_RE,
+    LAST_UPDATED_RE,
     apply_counts_to_readme,
+    apply_last_updated_to_readme,
+    format_last_updated,
     read_counts_from_jobs_json,
+    read_generated_at_from_jobs_json,
     sync_readme_counts,
 )
 
@@ -177,6 +183,150 @@ def test_count_token_re_matches_strict_form() -> None:
 # Cross-artifact invariant: README and docs/jobs.json agree at HEAD.
 # This is the CI gate the user asked for.
 # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Last-updated stamp
+# ---------------------------------------------------------------------------
+
+def test_read_generated_at_parses_iso_with_microseconds_and_offset(tmp_path) -> None:
+    jobs_path = tmp_path / "jobs.json"
+    jobs_path.write_text(json.dumps({
+        "meta": {"generated_at": "2026-05-26T19:52:33.997303+00:00", "total_jobs": 0, "categories": []},
+        "jobs": [],
+    }))
+    ts = read_generated_at_from_jobs_json(jobs_path)
+    assert ts == datetime(2026, 5, 26, 19, 52, 33, 997303, tzinfo=timezone.utc)
+
+
+def test_read_generated_at_handles_z_suffix(tmp_path) -> None:
+    jobs_path = tmp_path / "jobs.json"
+    jobs_path.write_text(json.dumps({
+        "meta": {"generated_at": "2026-05-26T19:52:33Z", "total_jobs": 0, "categories": []},
+        "jobs": [],
+    }))
+    ts = read_generated_at_from_jobs_json(jobs_path)
+    assert ts == datetime(2026, 5, 26, 19, 52, 33, tzinfo=timezone.utc)
+
+
+def test_read_generated_at_returns_none_on_missing_or_invalid(tmp_path) -> None:
+    cases = [
+        {"meta": {}, "jobs": []},
+        {"meta": {"generated_at": None}, "jobs": []},
+        {"meta": {"generated_at": ""}, "jobs": []},
+        {"meta": {"generated_at": "not-a-date"}, "jobs": []},
+    ]
+    for i, payload in enumerate(cases):
+        jobs_path = tmp_path / f"jobs_{i}.json"
+        jobs_path.write_text(json.dumps(payload))
+        assert read_generated_at_from_jobs_json(jobs_path) is None
+
+
+def test_format_last_updated_normalizes_to_utc() -> None:
+    # Non-UTC input is converted to UTC.
+    pacific = timezone(timedelta(hours=-7))
+    ts = datetime(2026, 5, 26, 12, 30, 0, tzinfo=pacific)
+    assert format_last_updated(ts) == "*Last updated: 2026-05-26 19:30:00 UTC*"
+
+    # Naive datetimes are assumed UTC.
+    naive = datetime(2026, 1, 1, 0, 0, 0)
+    assert format_last_updated(naive) == "*Last updated: 2026-01-01 00:00:00 UTC*"
+
+
+def test_apply_last_updated_rewrites_existing_line() -> None:
+    readme = (
+        "⭐ **Star this repo** to stay updated with the latest new grad opportunities!\n"
+        "\n"
+        "*Last updated: 2026-03-12 05:46:03 UTC*\n"
+    )
+    ts = datetime(2026, 5, 26, 19, 52, 33, tzinfo=timezone.utc)
+    out = apply_last_updated_to_readme(readme, ts)
+    assert "2026-03-12 05:46:03" not in out
+    assert "*Last updated: 2026-05-26 19:52:33 UTC*" in out
+
+
+def test_apply_last_updated_is_noop_when_ts_none() -> None:
+    readme = "*Last updated: 2026-03-12 05:46:03 UTC*\n"
+    assert apply_last_updated_to_readme(readme, None) == readme
+
+
+def test_apply_last_updated_is_noop_when_line_absent() -> None:
+    readme = "Some README without any last-updated line.\n"
+    ts = datetime(2026, 5, 26, 19, 52, 33, tzinfo=timezone.utc)
+    assert apply_last_updated_to_readme(readme, ts) == readme
+
+
+def test_apply_last_updated_only_rewrites_first_match() -> None:
+    # Defensive: if a future edit accidentally introduces multiple lines, we
+    # only replace one so a runaway substitution can't corrupt the file.
+    readme = (
+        "*Last updated: 2025-01-01 00:00:00 UTC*\n"
+        "Middle prose.\n"
+        "*Last updated: 2026-01-01 00:00:00 UTC*\n"
+    )
+    ts = datetime(2026, 5, 26, 19, 52, 33, tzinfo=timezone.utc)
+    out = apply_last_updated_to_readme(readme, ts)
+    assert out.count("*Last updated: 2026-05-26 19:52:33 UTC*") == 1
+    # Second line stays untouched.
+    assert "*Last updated: 2026-01-01 00:00:00 UTC*" in out
+
+
+def test_sync_readme_counts_rewrites_both_counts_and_stamp(tmp_path) -> None:
+    jobs_path = tmp_path / "docs" / "jobs.json"
+    jobs_path.parent.mkdir()
+    jobs_path.write_text(json.dumps({
+        "meta": {
+            "generated_at": "2026-05-26T19:52:33.997303+00:00",
+            "total_jobs": 1358,
+            "categories": [
+                {"id": "software_engineering", "name": "SWE", "emoji": "💻", "count": 880},
+            ],
+        },
+        "jobs": [],
+    }))
+    readme_path = tmp_path / "README.md"
+    readme_path.write_text(
+        "# Repo\n"
+        "<!-- COUNT:total -->0<!-- /COUNT -->\n"
+        "<!-- COUNT:software_engineering -->0<!-- /COUNT -->\n"
+        "\n"
+        "*Last updated: 2026-03-12 05:46:03 UTC*\n"
+    )
+
+    changed = sync_readme_counts(tmp_path)
+    assert changed is True
+
+    text = readme_path.read_text(encoding="utf-8")
+    assert "<!-- COUNT:total -->1358<!-- /COUNT -->" in text
+    assert "<!-- COUNT:software_engineering -->880<!-- /COUNT -->" in text
+    assert "*Last updated: 2026-05-26 19:52:33 UTC*" in text
+    assert "2026-03-12" not in text
+
+
+def test_repo_readme_last_updated_matches_jobs_json() -> None:
+    """README's trailing "Last updated" line must reflect docs/jobs.json.
+
+    If this fails, run `python scripts/sync_readme_counts.py` and commit the
+    diff (the scheduled scrape does this automatically going forward).
+    """
+    jobs_path = REPO_ROOT / "docs" / "jobs.json"
+    readme_path = REPO_ROOT / "README.md"
+
+    ts = read_generated_at_from_jobs_json(jobs_path)
+    if ts is None:
+        pytest.skip("docs/jobs.json has no parseable generated_at.")
+
+    readme_text = readme_path.read_text(encoding="utf-8")
+    match = LAST_UPDATED_RE.search(readme_text)
+    if not match:
+        pytest.skip("README has no Last-updated line yet (run sync once to add it).")
+
+    assert match.group(0) == format_last_updated(ts), (
+        f"README 'Last updated' is out of sync with docs/jobs.json.\n"
+        f"  README:    {match.group(0)}\n"
+        f"  jobs.json: {format_last_updated(ts)}\n"
+        f"Run: python scripts/sync_readme_counts.py"
+    )
+
 
 def test_repo_readme_matches_jobs_json() -> None:
     """README counts at HEAD must match docs/jobs.json counts.


### PR DESCRIPTION
## Why

The `*Last updated: YYYY-MM-DD HH:MM:SS UTC*` line at the very bottom of `README.md` was a hand-edited timestamp that had been stuck at **2026-03-12 05:46:03 UTC** — 2.5 months stale — even though the scraper commits to `main` multiple times per hour and rewrites the COUNT-marker totals on every run.

The line lives right below the auto-synced count markers, so a casual reader would conclude the whole README was 75 days old when in fact only the trailing stamp had rotted.

`sync_readme_counts.py` already runs after every scrape (invoked from `update_jobs.py:3425`). It just didn't own this line.

## What

Extends `sync_readme_counts.py` to:

- Parse `meta.generated_at` from `docs/jobs.json`.
  - Handles `+00:00` offset, legacy `Z` suffix, microseconds, and naive timestamps.
  - Returns `None` on any malformed input (no crashes; sync just no-ops the line).
- Format it as `*Last updated: YYYY-MM-DD HH:MM:SS UTC*`, normalising non-UTC inputs by converting to UTC first.
- Rewrite the existing line via a regex anchored to the literal `*Last updated:` prefix and `UTC*` suffix.
  - Only the first match is rewritten, so a stray duplicate line later cannot trigger a runaway substitution.
- No-op posture: silent skip if `generated_at` is unparseable, or if the README has no recognisable line — same posture as the existing COUNT-marker path.

Ran the sync once locally so this PR also unsticks the live README:

| | Before | After |
|---|---|---|
| Line 1204 | `*Last updated: 2026-03-12 05:46:03 UTC*` | `*Last updated: 2026-05-26 19:52:33 UTC*` |

The COUNT tokens were already accurate (sync was running for them); only the trailing stamp was rotted.

## Tests (`+10`, all green)

- `read_generated_at` — parses ISO with microseconds + offset, legacy `Z`, returns None on missing/invalid.
- `format_last_updated` — normalises Pacific time and naive datetimes to UTC.
- `apply_last_updated_to_readme` — rewrites existing line, no-op on None / missing line / multiple matches.
- `sync_readme_counts_rewrites_both_counts_and_stamp` — end-to-end check that one call updates both pieces.
- `test_repo_readme_last_updated_matches_jobs_json` — CI invariant mirroring the existing count-marker invariant; will fail at HEAD if the live README drifts again.

```
$ python3 -m pytest tests/test_readme_sync.py tests/test_readme_contract.py -v
======================== 27 passed in 0.19s ========================
$ python3 -m pytest tests/ -q --no-cov
======================== 733 passed in 9.11s ========================
```

## What this does *not* change

- The scraper's `*/5` cron, runtime, or workflow concurrency.
- The COUNT-marker contract (still strict, still digits-only).
- The README's prose, tables, badges, headings, or layout.