### PR TITLE
fix(ui): add favicon to eliminate /favicon.ico 404 (#305)

### DIFF
--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  NGJ favicon. Terminal-aesthetic monogram on the same palette as the
+  contributors view: bg #000, accent #ff9d3d, ok #5fd28a (LIVE dot).
+  Single SVG with no external font dependency — uses a hand-laid "NGJ"
+  glyph drawn as polylines so it renders identically at 16, 32, 48, and
+  256 px without any font-loading FOIT in the browser tab.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect width="64" height="64" rx="10" fill="#0a0a0a"/>
+  <!-- LIVE dot (top-right), echoing the chip in the app header -->
+  <circle cx="51" cy="13" r="4" fill="#5fd28a"/>
+  <!-- NGJ monogram in the brand amber -->
+  <g fill="none" stroke="#ff9d3d" stroke-width="4.5" stroke-linecap="square" stroke-linejoin="miter">
+    <!-- N -->
+    <polyline points="10,46 10,22 22,46 22,22"/>
+    <!-- G (open right side, with bottom-right tick) -->
+    <polyline points="42,22 30,22 30,46 42,46 42,34 36,34"/>
+    <!-- J -->
+    <polyline points="56,22 56,42 52,46 47,46 44,42"/>
+  </g>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,6 +11,8 @@
   <meta name="twitter:card" content="summary_large_image">
   <title>NGJ · New Grad Jobs</title>
 
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preconnect" href="https://gc.zgo.at" crossorigin>


### PR DESCRIPTION
Closes #305.

## Why

Every visit to https://jobs.riteshrana.engineer/ logged a 404 in the browser console:

\`\`\`
GET https://jobs.riteshrana.engineer/favicon.ico → 404
\`\`\`

The tab icon was also blank in every browser. \`docs/\` had no favicon asset and \`docs/index.html\` had no \`<link rel=\"icon\">\` tag, so browsers fell back to the auto-requested \`/favicon.ico\` path which doesn't exist on GitHub Pages.

## What

- **\`docs/favicon.svg\`** — terminal-aesthetic NGJ monogram on the exact same palette as the contributors view: \`#0a0a0a\` panel + \`#ff9d3d\` accent + \`#5fd28a\` LIVE dot in the corner echoing the chip in the app header. Drawn as polylines (no font dependency), sharp at every browser-tab size from 16 to 256 px.
- **\`docs/index.html\`** — adds \`<link rel=\"icon\" type=\"image/svg+xml\" href=\"favicon.svg\">\` immediately after \`<title>\`.

Single SVG — no \`.ico\` PNG fallback needed; all major browsers (Chrome, Firefox, Safari, Edge) have supported SVG favicons for years. If a legacy-browser report comes in later we can add an \`.ico\` then.

## Validation

Local: \`python3 -m http.server 8765\` in \`docs/\` + Playwright against \`http://localhost:8765/\`:

| Check | Before | After |
|---|---|---|
| \`GET /favicon.svg\` | 404 (missing file) | **200** |
| \`<link rel=\"icon\">\` in DOM | absent | **\`favicon.svg\`, \`image/svg+xml\`** |
| Console errors on \`/\` load | 1 (favicon 404) | **0** |
| LIVE chip + jobs feed | working | unchanged |

## Out of scope

- No \`.ico\` PNG fallback (modern browsers all support SVG favicons).
- No \`apple-touch-icon\` / manifest changes — separate UX surface, will be tackled if/when there's demand for "Add to Home Screen" on iOS/Android.
- No cache-bust query on the favicon \`<link>\` — browsers re-fetch favicons on Last-Modified change anyway, and we want the new icon to land for existing visitors without a forced reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added favicon to the website for improved visual branding in browser tabs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ambicuity/New-Grad-Jobs/pull/306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->