### PR TITLE
feat(ui): make HIRING NOW companies clickable to filter the job list (#307)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -61,15 +61,15 @@
   </div>
 
   <!-- Pure-JS helper for the LIVE chip, loadable in Node for unit testing. -->
-  <script src="terminal/live-stamp-format.js?v=9"></script>
+  <script src="terminal/live-stamp-format.js?v=10"></script>
 
   <!-- Cache-bust the bundle when its shape changes. Bump v= on data-shape edits. -->
-  <script type="text/babel" src="terminal/data.jsx?v=9"></script>
-  <script type="text/babel" src="terminal/contributors-data.jsx?v=9"></script>
-  <script type="text/babel" src="terminal/dashboard.jsx?v=9"></script>
-  <script type="text/babel" src="terminal/contributors.jsx?v=9"></script>
-  <script type="text/babel" src="terminal/live-stamp.jsx?v=9"></script>
-  <script type="text/babel" src="terminal/app.jsx?v=9"></script>
+  <script type="text/babel" src="terminal/data.jsx?v=10"></script>
+  <script type="text/babel" src="terminal/contributors-data.jsx?v=10"></script>
+  <script type="text/babel" src="terminal/dashboard.jsx?v=10"></script>
+  <script type="text/babel" src="terminal/contributors.jsx?v=10"></script>
+  <script type="text/babel" src="terminal/live-stamp.jsx?v=10"></script>
+  <script type="text/babel" src="terminal/app.jsx?v=10"></script>
 
   <script type="text/babel">
     (async () => {

--- a/docs/terminal/dashboard.jsx
+++ b/docs/terminal/dashboard.jsx
@@ -22,6 +22,7 @@ function DashboardDirection() {
   const [q, setQ] = useState2('');
   const [filters, setFilters] = useState2({
     type: new Set(), rmt: new Set(), visa: null, cohort: new Set(['26']), size: new Set(),
+    company: new Set(),
   });
   const [sortKey, setSortKey] = useState2('deadline');
   const [sortDir, setSortDir] = useState2(1);
@@ -45,8 +46,12 @@ function DashboardDirection() {
   });
   const setVisa = (val) => setFilters(f => ({ ...f, visa: f.visa === val ? null : val }));
 
-  const filtered = useMemo2(() => {
-    let out = NGJOBS.filter(j => {
+  // Pre-company filter: applies every facet EXCEPT company. Used as the source
+  // for the HIRING NOW sidebar so the list of companies doesn't collapse to
+  // just the selected company — users can still switch between companies even
+  // after picking one.
+  const preCompanyFiltered = useMemo2(() => {
+    return NGJOBS.filter(j => {
       if (filters.type.size && !filters.type.has(j.type)) return false;
       if (filters.rmt.size && !filters.rmt.has(j.rmt)) return false;
       if (filters.visa !== null && j.visa !== filters.visa) return false;
@@ -58,13 +63,19 @@ function DashboardDirection() {
       }
       return true;
     });
+  }, [filters.type, filters.rmt, filters.visa, filters.cohort, filters.size, q]);
+
+  const filtered = useMemo2(() => {
+    let out = filters.company.size
+      ? preCompanyFiltered.filter(j => filters.company.has(j.co))
+      : preCompanyFiltered.slice();
     const dir = sortDir;
     if (sortKey === 'deadline') out.sort((a,b) => dir*(daysLeft(a.dl) - daysLeft(b.dl)));
     if (sortKey === 'comp')     out.sort((a,b) => dir*(b.comp[1] - a.comp[1]));
     if (sortKey === 'co')       out.sort((a,b) => dir*a.co.localeCompare(b.co));
     if (sortKey === 'posted')   out.sort((a,b) => dir*a.posted.localeCompare(b.posted));
     return out;
-  }, [filters, q, sortKey, sortDir]);
+  }, [preCompanyFiltered, filters.company, sortKey, sortDir]);
 
   useEffect2(() => {
     if (!filtered.find(j => j.id === selectedId) && filtered[0]) setSelectedId(filtered[0].id);
@@ -125,12 +136,14 @@ function DashboardDirection() {
     return () => window.removeEventListener('keydown', onKey);
   }, [filtered, selectedId, saved, sortKey, helpOpen]);
 
-  // company-frequency for hot-companies widget
+  // company-frequency for the HIRING NOW widget. Derived from the
+  // pre-company filter so picking a company doesn't collapse the list —
+  // the user can still switch between companies after clicking one.
   const coCounts = useMemo2(() => {
     const m = new Map();
-    filtered.forEach(j => m.set(j.co, (m.get(j.co) || 0) + 1));
+    preCompanyFiltered.forEach(j => m.set(j.co, (m.get(j.co) || 0) + 1));
     return [...m.entries()].sort((a,b) => b[1]-a[1]);
-  }, [filtered]);
+  }, [preCompanyFiltered]);
 
   // Deadline buckets
   const buckets = useMemo2(() => {
@@ -216,12 +229,34 @@ function DashboardDirection() {
               <span style={{ color: BBG.acc }}>{coCounts.length}</span>
             </div>
             <div style={{ maxHeight: 220, overflowY: 'auto' }}>
-              {coCounts.map(([co, n]) => (
-                <div key={co} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontSize: 11, padding: '1px 0' }}>
-                  <span style={{ color: BBG.ink }}>{co}</span>
-                  <span style={{ color: BBG.acc }}>{n}</span>
-                </div>
-              ))}
+              {coCounts.map(([co, n]) => {
+                const active = filters.company.has(co);
+                return (
+                  <div
+                    key={co}
+                    role="button"
+                    tabIndex={0}
+                    aria-pressed={active}
+                    title={active ? `clear filter: ${co}` : `filter to ${co}`}
+                    onClick={() => toggleSet('company', co)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        toggleSet('company', co);
+                      }
+                    }}
+                    style={{
+                      display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                      fontSize: 11, padding: '1px 4px', cursor: 'pointer',
+                      background: active ? BBG.panel2 : 'transparent',
+                      borderLeft: `2px solid ${active ? BBG.acc : 'transparent'}`,
+                    }}
+                  >
+                    <span style={{ color: active ? BBG.acc : BBG.ink }}>{co}</span>
+                    <span style={{ color: BBG.acc }}>{n}</span>
+                  </div>
+                );
+              })}
             </div>
           </div>
         </div>


### PR DESCRIPTION
Closes #307.

## Why

The HIRING NOW sidebar listed every company with its open-role count, but the rows had no click handler. Visitors landed on jobs.riteshrana.engineer/#hiring and naturally tried to click \"SpaceX\" or \"OpenAI\" expecting the center table to narrow to that company's roles (and the right-hand detail panel to switch to the first match) — the affordance the dense Bloomberg-terminal layout implies — but nothing happened.

## What

Wired the HIRING NOW rows up as toggleable filter chips. Click a company → table narrows. Click again → table expands back. Multi-select supported.

Changes in \`docs/terminal/dashboard.jsx\`:

- Added \`company: new Set()\` to the \`filters\` state so the existing \`toggleSet('company', co)\` plumbing works without new helpers.
- Split the memoized job filter into two stages:
  - \`preCompanyFiltered\` — every facet **except** company (used by the sidebar so it doesn't collapse).
  - \`filtered\` — applies the company set on top of \`preCompanyFiltered\`.
- Source \`coCounts\` from \`preCompanyFiltered\`. Without this, clicking \"SpaceX\" would collapse the HIRING NOW list to one row.
- Each row is now a clickable element with \`role=\"button\"\`, \`aria-pressed\`, keyboard activation on Enter/Space, a tooltip, and a selected visual state (panel2 bg + amber accent text + amber border-left). \`cursor: pointer\` makes the affordance discoverable.
- Right-hand detail panel updates via the existing \`useEffect\` that moves \`selectedId\` to the first matching job when \`filtered\` changes — no extra wiring needed.

Bumped \`?v=9\` → \`?v=10\` on every bundle in \`docs/index.html\` so existing visitors fetch the new \`dashboard.jsx\` on next load.

## Verification (Playwright against \`python3 -m http.server 8765\`)

| Action | Expected | Actual |
|---|---|---|
| Initial load | 1339/1339 results, 0 active filters | ✓ |
| Click \"SpaceX\" | results drop to 186/1339, table top is all SpaceX | ✓ — first row: Application Software Engineer, Hawthorne CA |
| Inspect row | \`aria-pressed=true\`, amber border-left, panel2 bg | ✓ — \`borderLeft: 2px solid rgb(255, 157, 61)\`, \`bg: rgb(16, 16, 16)\` |
| Click \"Anduril\" with SpaceX still active | multi-select: 186 + 164 = 350 | ✓ — 350/1339 |
| Click each active row again | filter clears, back to 1339/1339 | ✓ |
| HIRING NOW list count after selection | stays at 233 rows | ✓ (doesn't collapse) |
| Console errors before / after | 0 / 0 | ✓ |

Screenshot taken locally: \`company-filter-active.png\` (OpenAI selected, 45/1339 results, table top all-OpenAI roles).

## Out of scope (kept explicitly small)

- URL persistence of the active company filter (issue #307 explicitly listed this as out of scope).
- Keyboard navigation across the company list with arrow keys.
- A clear-all-companies button (each row's deselect-on-second-click covers the common case; can add later if 3+ multi-select usage shows up).