### PR TITLE
feat(ui): add SPONSOR button to top bar linking to Buy Me a Coffee

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -61,15 +61,15 @@
   </div>
 
   <!-- Pure-JS helper for the LIVE chip, loadable in Node for unit testing. -->
-  <script src="terminal/live-stamp-format.js?v=10"></script>
+  <script src="terminal/live-stamp-format.js?v=11"></script>
 
   <!-- Cache-bust the bundle when its shape changes. Bump v= on data-shape edits. -->
-  <script type="text/babel" src="terminal/data.jsx?v=10"></script>
-  <script type="text/babel" src="terminal/contributors-data.jsx?v=10"></script>
-  <script type="text/babel" src="terminal/dashboard.jsx?v=10"></script>
-  <script type="text/babel" src="terminal/contributors.jsx?v=10"></script>
-  <script type="text/babel" src="terminal/live-stamp.jsx?v=10"></script>
-  <script type="text/babel" src="terminal/app.jsx?v=10"></script>
+  <script type="text/babel" src="terminal/data.jsx?v=11"></script>
+  <script type="text/babel" src="terminal/contributors-data.jsx?v=11"></script>
+  <script type="text/babel" src="terminal/dashboard.jsx?v=11"></script>
+  <script type="text/babel" src="terminal/contributors.jsx?v=11"></script>
+  <script type="text/babel" src="terminal/live-stamp.jsx?v=11"></script>
+  <script type="text/babel" src="terminal/app.jsx?v=11"></script>
 
   <script type="text/babel">
     (async () => {

--- a/docs/terminal/app.jsx
+++ b/docs/terminal/app.jsx
@@ -71,9 +71,40 @@ function TopBar({ tab, setTab }) {
       {/* Right meta */}
       <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 14, padding: '0 14px', fontSize: 11, color: '#6e6e6e' }}>
         <LiveStamp />
+        <SponsorLink />
         <span style={{ border: '1px solid #2a2a2a', padding: '2px 6px', color: '#e8e8e8' }}>F1 HELP</span>
       </div>
     </div>
+  );
+}
+
+function SponsorLink() {
+  const [hover, setHover] = useStateApp(false);
+  return (
+    <a
+      href="https://buymeacoffee.com/ritesh.rana"
+      target="_blank"
+      rel="noopener noreferrer"
+      title="Support the maintainer on Buy Me a Coffee"
+      aria-label="Sponsor on Buy Me a Coffee (opens in a new tab)"
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      onFocus={() => setHover(true)}
+      onBlur={() => setHover(false)}
+      style={{
+        display: 'inline-flex', alignItems: 'center', gap: 6,
+        border: '1px solid #ff9d3d',
+        background: hover ? '#1a1407' : 'transparent',
+        padding: '2px 8px',
+        color: '#ff9d3d',
+        textDecoration: 'none',
+        fontWeight: 600, letterSpacing: 0.5,
+        transition: 'background 120ms ease',
+      }}
+    >
+      <span aria-hidden="true">☕</span>
+      <span>SPONSOR</span>
+    </a>
   );
 }
 


### PR DESCRIPTION
Adds a compact \`☕ SPONSOR\` link to the top-right meta area of the app's top bar. Clicking it opens https://buymeacoffee.com/ritesh.rana in a new tab.

## Decisions

- **Why Buy Me a Coffee, not GitHub Sponsors**: the maintainer asked for it explicitly and provided the BMaC URL. One button, one funnel — no second affordance to split attention.
- **Why a terminal-styled button, not BMaC's native yellow chrome**: the app is a dense Bloomberg-terminal UI. Pulling in the BMaC branded button would clash. Reusing the existing amber (\`#ff9d3d\`) gives it the right visual weight without breaking the chrome.
- **Why position between the LIVE chip and F1 HELP**: scanning order is **status → action → hint**. The LIVE chip is the most informational item on the right; SPONSOR is the only *interactive* item there, so it gets the middle slot. F1 HELP is a passive keyboard-shortcut hint, so it goes last.
- **Why a single SVG/text button, not a hover popover with extra options**: keeps the top bar clean. The funnel is one tap.

## Implementation

\`docs/terminal/app.jsx\`:

- Added \`SponsorLink\` component, rendered between \`<LiveStamp />\` and the F1 HELP chip.
- External-link safety: \`target=\"_blank\"\` + \`rel=\"noopener noreferrer\"\` so the BMaC tab can't reach back via \`window.opener\`.
- Accessibility: explicit \`aria-label\`, \`title\` tooltip, \`aria-hidden\` on the decorative \`☕\` glyph so screen readers don't announce \"hot beverage emoji SPONSOR\". Focus state matches hover (background flips on both \`focus\` and \`mouseenter\`), not just hover.

\`docs/index.html\`:

- Cache-bust \`?v=10\` → \`?v=11\` across every bundle so existing visitors fetch the new \`app.jsx\` on next load.

## Verification (local — \`python3 -m http.server 8765\` + Playwright)

| Check | Result |
|---|---|
| Button in DOM | \`<a href=\"https://buymeacoffee.com/ritesh.rana\">\` ✓ |
| External-link safety | \`target=_blank\`, \`rel=\"noopener noreferrer\"\` ✓ |
| ARIA | \`aria-label=\"Sponsor on Buy Me a Coffee (opens in a new tab)\"\` ✓ |
| Visible label | \`☕ SPONSOR\` ✓ |
| Position | top-right, 88 px from window right edge (between LIVE chip and F1 HELP) ✓ |
| Style | amber border \`#ff9d3d\` on transparent bg, flips to panel2 on hover/focus ✓ |
| Console errors | 0 ✓ |

Screenshot saved locally to \`sponsor-button.png\`.

## Out of scope

- GitHub Sponsors integration (single-funnel decision).
- A second \"Star on GitHub\" button — separate task, separate optimization.
- Analytics on click — none of the existing app code instruments link clicks; can add a goatcounter event later if it's worth measuring.