### PR TITLE
feat(ui): add bottom-right site footer with nav, social, and version

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -61,15 +61,15 @@
   </div>
 
   <!-- Pure-JS helper for the LIVE chip, loadable in Node for unit testing. -->
-  <script src="terminal/live-stamp-format.js?v=11"></script>
+  <script src="terminal/live-stamp-format.js?v=12"></script>
 
   <!-- Cache-bust the bundle when its shape changes. Bump v= on data-shape edits. -->
-  <script type="text/babel" src="terminal/data.jsx?v=11"></script>
-  <script type="text/babel" src="terminal/contributors-data.jsx?v=11"></script>
-  <script type="text/babel" src="terminal/dashboard.jsx?v=11"></script>
-  <script type="text/babel" src="terminal/contributors.jsx?v=11"></script>
-  <script type="text/babel" src="terminal/live-stamp.jsx?v=11"></script>
-  <script type="text/babel" src="terminal/app.jsx?v=11"></script>
+  <script type="text/babel" src="terminal/data.jsx?v=12"></script>
+  <script type="text/babel" src="terminal/contributors-data.jsx?v=12"></script>
+  <script type="text/babel" src="terminal/dashboard.jsx?v=12"></script>
+  <script type="text/babel" src="terminal/contributors.jsx?v=12"></script>
+  <script type="text/babel" src="terminal/live-stamp.jsx?v=12"></script>
+  <script type="text/babel" src="terminal/app.jsx?v=12"></script>
 
   <script type="text/babel">
     (async () => {

--- a/docs/terminal/app.jsx
+++ b/docs/terminal/app.jsx
@@ -16,12 +16,13 @@ function NGApp() {
     <div style={{
       width: '100%', height: '100%', background: '#000', color: '#e8e8e8',
       fontFamily: '"JetBrains Mono", ui-monospace, monospace',
-      display: 'grid', gridTemplateRows: 'auto 1fr', overflow: 'hidden',
+      display: 'grid', gridTemplateRows: 'auto 1fr auto', overflow: 'hidden',
     }}>
       <TopBar tab={tab} setTab={setTab} />
       <div style={{ minHeight: 0, overflow: 'hidden' }}>
         {tab === 'hiring' ? <DashboardDirection /> : <ContributorsView />}
       </div>
+      <SiteFooter />
     </div>
   );
 }
@@ -75,6 +76,69 @@ function TopBar({ tab, setTab }) {
         <span style={{ border: '1px solid #2a2a2a', padding: '2px 6px', color: '#e8e8e8' }}>F1 HELP</span>
       </div>
     </div>
+  );
+}
+
+function SiteFooter() {
+  // Bottom-right footer block — adapted from a foorilla-style three-section
+  // layout (nav links / socials / version+copyright) to our terminal palette.
+  // Right-aligned within a thin row beneath the tab-level status bar so it
+  // doesn't overlap the dense main content above.
+  const REPO = 'https://github.com/ambicuity/New-Grad-Jobs';
+  const links = [
+    { href: REPO,                                    label: 'Repo',   ext: true },
+    { href: `${REPO}/blob/main/README.md`,           label: 'README', ext: true },
+    { href: `${REPO}/issues`,                        label: 'Issues', ext: true },
+    { href: 'jobs.json',                             label: 'API',    ext: false, title: 'Public JSON feed of all jobs' },
+    { href: 'feed.xml',                              label: 'RSS',    ext: false },
+    { href: `${REPO}/actions/workflows/update-jobs.yml`, label: 'Status', ext: true, title: 'Scraper workflow runs' },
+  ];
+  const socials = [
+    { href: 'https://github.com/ambicuity',          label: 'GH', title: 'Ritesh Rana on GitHub' },
+    { href: 'https://buymeacoffee.com/ritesh.rana',  label: 'BMC', title: 'Buy Me a Coffee' },
+  ];
+  return (
+    <div style={{
+      display: 'flex', justifyContent: 'flex-end',
+      borderTop: '1px solid #2a2a2a', background: '#0a0a0a',
+      padding: '4px 14px', gap: 14,
+      fontSize: 10, color: '#6e6e6e', letterSpacing: 0.3, flexWrap: 'wrap',
+    }}>
+      <FooterRow items={links} />
+      <FooterRow items={socials} />
+      <span>
+        <span title="Continuously deployed from main">rolling · main</span>
+        {' · '}Made with <span aria-hidden="true">☕ + ♥️</span>
+        {' · '}© 2026{' '}
+        <a href="https://github.com/ambicuity" target="_blank" rel="noopener noreferrer"
+           style={{ color: '#6e6e6e', textDecoration: 'none', borderBottom: '1px dotted #2a2a2a' }}>
+          ambicuity
+        </a>
+      </span>
+    </div>
+  );
+}
+
+function FooterRow({ items }) {
+  return (
+    <span>
+      {items.map((it, i) => (
+        <span key={it.label}>
+          <a
+            href={it.href}
+            target={it.ext === false ? undefined : '_blank'}
+            rel={it.ext === false ? undefined : 'noopener noreferrer'}
+            title={it.title || it.label}
+            style={{ color: '#6e6e6e', textDecoration: 'none', borderBottom: '1px dotted #2a2a2a' }}
+            onMouseEnter={(e) => { e.currentTarget.style.color = '#ff9d3d'; }}
+            onMouseLeave={(e) => { e.currentTarget.style.color = '#6e6e6e'; }}
+          >
+            {it.label}
+          </a>
+          {i < items.length - 1 ? ' · ' : ''}
+        </span>
+      ))}
+    </span>
   );
 }
 

--- a/docs/terminal/app.jsx
+++ b/docs/terminal/app.jsx
@@ -108,7 +108,7 @@ function SiteFooter() {
       <FooterRow items={socials} />
       <span>
         <span title="Continuously deployed from main">rolling · main</span>
-        {' · '}Made with <span aria-hidden="true">☕ + ♥️</span>
+        {' · '}Made with <span aria-hidden="true">♥️</span>
         {' · '}© 2026{' '}
         <a href="https://github.com/ambicuity" target="_blank" rel="noopener noreferrer"
            style={{ color: '#6e6e6e', textDecoration: 'none', borderBottom: '1px dotted #2a2a2a' }}>


### PR DESCRIPTION
Adapts a foorilla-style three-section footer (nav / socials / version+copyright) to the terminal aesthetic. Right-aligned thin row at the bottom of the app shell, visible on both #hiring and #contributors.

## Sections

| Section | Links | Notes |
|---|---|---|
| Nav | Repo · README · Issues · API · RSS · Status | API/RSS same-origin (\`/jobs.json\`, \`/feed.xml\`); rest open in new tab |
| Social | GH (ambicuity profile) · BMC (Buy Me a Coffee) | BMC converges with the top-bar SPONSOR button on the same funnel |
| Version | \`rolling · main\` · \`Made with ☕ + ♥️\` · \`© 2026 ambicuity\` | "rolling · main" tooltip clarifies continuous deployment (no semver releases) |

## Implementation

- \`NGApp\` \`gridTemplateRows\`: \`'auto 1fr'\` → \`'auto 1fr auto'\`. Footer occupies its own row — **no floating overlay, no overlap** with the tab-level status bar.
- Footer styling: panel bg \`#0a0a0a\` + 1 px top border, dim ink \`#6e6e6e\`, dotted-underline links that flip to amber \`#ff9d3d\` on hover (inline mouseenter/leave, consistent with the rest of \`app.jsx\`).
- External links: \`target=\"_blank\"\` + \`rel=\"noopener noreferrer\"\`. Same-origin (\`API\`, \`RSS\`) deliberately stay in the tab.
- \`flexWrap: wrap\` so sections collapse cleanly on narrow viewports.
- Decorative glyphs (\`☕\`, \`♥️\`) carry \`aria-hidden\` so screen readers don't announce them.
- Cache-bust \`?v=11\` → \`?v=12\` so existing visitors fetch the new bundle.

## Verification (local — \`python3 -m http.server 8765\` + Playwright)

| Check | Result |
|---|---|
| Footer renders on #hiring | 9 anchors present (8 link labels + copyright link) |
| Footer renders on #contributors | 8 link anchors present, "rolling · main" + "© 2026" present |
| href / target / rel | all correct (external = \`_blank\` + \`noopener noreferrer\`; same-origin = empty target) |
| Console errors | 0 before, 0 after |
| BMC link | matches the top-bar SPONSOR (\`buymeacoffee.com/ritesh.rana\`) |

Screenshots saved locally: \`site-footer-hiring.png\`, \`site-footer-contributors.png\`.

## Out of scope

- Status page / changelog modal (foorilla uses htmx-driven modals for these; we'd need a richer routing story).
- Job-posting form (out of scope for a scraper-only project).
- Privacy / Terms pages (no analytics + no PII collection in our pipeline; can add when/if that changes).
- Twitter/LinkedIn social links (the maintainer hasn't published verified URLs for those; not making them up).