### PR TITLE
fix(ui): sort POSTED column chronologically, not alphabetically (#311)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -61,15 +61,15 @@
   </div>
 
   <!-- Pure-JS helper for the LIVE chip, loadable in Node for unit testing. -->
-  <script src="terminal/live-stamp-format.js?v=12"></script>
+  <script src="terminal/live-stamp-format.js?v=13"></script>
 
   <!-- Cache-bust the bundle when its shape changes. Bump v= on data-shape edits. -->
-  <script type="text/babel" src="terminal/data.jsx?v=12"></script>
-  <script type="text/babel" src="terminal/contributors-data.jsx?v=12"></script>
-  <script type="text/babel" src="terminal/dashboard.jsx?v=12"></script>
-  <script type="text/babel" src="terminal/contributors.jsx?v=12"></script>
-  <script type="text/babel" src="terminal/live-stamp.jsx?v=12"></script>
-  <script type="text/babel" src="terminal/app.jsx?v=12"></script>
+  <script type="text/babel" src="terminal/data.jsx?v=13"></script>
+  <script type="text/babel" src="terminal/contributors-data.jsx?v=13"></script>
+  <script type="text/babel" src="terminal/dashboard.jsx?v=13"></script>
+  <script type="text/babel" src="terminal/contributors.jsx?v=13"></script>
+  <script type="text/babel" src="terminal/live-stamp.jsx?v=13"></script>
+  <script type="text/babel" src="terminal/app.jsx?v=13"></script>
 
   <script type="text/babel">
     (async () => {

--- a/docs/terminal/dashboard.jsx
+++ b/docs/terminal/dashboard.jsx
@@ -73,7 +73,7 @@ function DashboardDirection() {
     if (sortKey === 'deadline') out.sort((a,b) => dir*(daysLeft(a.dl) - daysLeft(b.dl)));
     if (sortKey === 'comp')     out.sort((a,b) => dir*(b.comp[1] - a.comp[1]));
     if (sortKey === 'co')       out.sort((a,b) => dir*a.co.localeCompare(b.co));
-    if (sortKey === 'posted')   out.sort((a,b) => dir*a.posted.localeCompare(b.posted));
+    if (sortKey === 'posted')   out.sort((a,b) => dir*(b.postedTs - a.postedTs));
     return out;
   }, [preCompanyFiltered, filters.company, sortKey, sortDir]);
 

--- a/docs/terminal/data.jsx
+++ b/docs/terminal/data.jsx
@@ -132,6 +132,11 @@ function mapJob(j) {
     dl:      addDays(j.posted_at, 90),       // synthetic 90-day window
     type:    deriveType(j),
     posted:  ageString(j.posted_at),
+    // Raw timestamp for chronological sort. ageString() is for display only;
+    // sorting on its output yields lexicographic order ("1d" < "1w" < "2d" …)
+    // rather than recency. 0 here means "no timestamp" — those rows sort last
+    // under the descending (newest-first) default.
+    postedTs: j.posted_at ? new Date(j.posted_at).getTime() || 0 : 0,
     level:   'entry',
     desc:    (j.full_description && j.full_description.length > 60)
                ? j.full_description


### PR DESCRIPTION
Closes #311.

## Why

Clicking the POSTED column header in the dashboard fired a sort but the result was ordered **alphabetically on the relative-time display string** (\`\"1d\"\`, \`\"2w\"\`, \`\"3mo\"\`, \`\"now\"\`), not by recency:

\`\`\`js
out.sort((a, b) => dir * a.posted.localeCompare(b.posted));
\`\`\`

Lexicographic order on those strings is meaningless:

\`\`\`
\"1d\" < \"1w\" < \"2d\" < \"2w\" < \"30d\" < \"3h\" < \"now\"
\`\`\`

On a new-grad board where freshness is a primary signal, this column was actively misleading.

## What

- \`docs/terminal/data.jsx\` — plumb the raw ISO timestamp through onto the mapped \`NGJOBS\` rows as \`postedTs\` (ms-since-epoch, \`0\` fallback for rows that lack \`posted_at\`). The existing \`posted\` field stays as the formatted \`ageString()\` output for display.
- \`docs/terminal/dashboard.jsx\` — switch the comparator to a numeric subtraction:

  \`\`\`js
  out.sort((a, b) => dir * (b.postedTs - a.postedTs));
  \`\`\`

  With \`dir=1\` (the default on the first click) the result is now **newest-first**, which is what a job-board reader expects from the ▲ glyph in this column. Clicking again flips to oldest-first ▼.

- Cache-bust \`?v=12\` → \`?v=13\` so existing visitors fetch the new bundles.

## Verification (local — \`python3 -m http.server 8765\` + Playwright)

| Action | Expected | Actual |
|---|---|---|
| First click on POSTED | ▲, top rows all \`now\` (newest) | ✓ — Anduril (DevOps), Scopely (DS), Fivetran (Systems), Squarespace (SE Delivery), xAI (App Sec, Data Engineer) |
| Second click on POSTED | ▼, top rows all \`1mo\` (oldest within window) | ✓ — OpenAI (Workload Enablement, System Enablement), Crusoe (SDN Networking) |
| Console errors before / after | 0 / 0 | ✓ |

Screenshot: \`posted-sort-fixed.png\` (newest-first view).

## Out of scope

- Touching the other sort comparators (\`deadline\`, \`comp\`, \`co\`) — they were already comparing numerically or via \`localeCompare\` on real strings; no fix needed.
- Persisting sort state in the URL.