### PR TITLE
fix(ui): default the job-table sort to POSTED instead of DEADLINE

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -61,15 +61,15 @@
   </div>
 
   <!-- Pure-JS helper for the LIVE chip, loadable in Node for unit testing. -->
-  <script src="terminal/live-stamp-format.js?v=13"></script>
+  <script src="terminal/live-stamp-format.js?v=14"></script>
 
   <!-- Cache-bust the bundle when its shape changes. Bump v= on data-shape edits. -->
-  <script type="text/babel" src="terminal/data.jsx?v=13"></script>
-  <script type="text/babel" src="terminal/contributors-data.jsx?v=13"></script>
-  <script type="text/babel" src="terminal/dashboard.jsx?v=13"></script>
-  <script type="text/babel" src="terminal/contributors.jsx?v=13"></script>
-  <script type="text/babel" src="terminal/live-stamp.jsx?v=13"></script>
-  <script type="text/babel" src="terminal/app.jsx?v=13"></script>
+  <script type="text/babel" src="terminal/data.jsx?v=14"></script>
+  <script type="text/babel" src="terminal/contributors-data.jsx?v=14"></script>
+  <script type="text/babel" src="terminal/dashboard.jsx?v=14"></script>
+  <script type="text/babel" src="terminal/contributors.jsx?v=14"></script>
+  <script type="text/babel" src="terminal/live-stamp.jsx?v=14"></script>
+  <script type="text/babel" src="terminal/app.jsx?v=14"></script>
 
   <script type="text/babel">
     (async () => {

--- a/docs/terminal/dashboard.jsx
+++ b/docs/terminal/dashboard.jsx
@@ -24,7 +24,7 @@ function DashboardDirection() {
     type: new Set(), rmt: new Set(), visa: null, cohort: new Set(['26']), size: new Set(),
     company: new Set(),
   });
-  const [sortKey, setSortKey] = useState2('deadline');
+  const [sortKey, setSortKey] = useState2('posted');
   const [sortDir, setSortDir] = useState2(1);
   const [selectedId, setSelectedId] = useState2(NGJOBS[5].id);
   const [saved, setSaved] = useState2(new Set(['ant-mlr-26','crs-swe-26']));
@@ -126,7 +126,7 @@ function DashboardDirection() {
         }
       } else if (e.key === 'F2') {
         e.preventDefault();
-        const keys = ['deadline','comp','co','posted'];
+        const keys = ['posted','deadline','comp','co'];
         const next = keys[(keys.indexOf(sortKey) + 1) % keys.length];
         setSortKey(next);
         flashToast(`sort: ${next}`, BBG.acc2);
@@ -387,7 +387,7 @@ function DashboardDirection() {
               ['↑ ↓ (or j k)', 'navigate jobs'],
               ['⏎',     'open application'],
               ['s / F3', 'save toggle'],
-              ['F2',    'cycle sort: deadline → comp → co → posted'],
+              ['F2',    'cycle sort: posted → deadline → comp → co'],
               ['?',     'show this help'],
             ].map(([k, v]) => (
               <div key={k} style={{ display: 'grid', gridTemplateColumns: '160px 1fr', padding: '4px 0', fontSize: 12 }}>


### PR DESCRIPTION
## Why

A new-grad job-board reader primarily cares about **fresh** listings, not about how soon a deadline expires (which in our case is a synthetic 90-day window computed in \`data.jsx:132\` — \`addDays(j.posted_at, 90)\` — so it conveys nothing real about deadline urgency). Defaulting to POSTED puts the newest postings on top from the moment the page loads, matching the LIVE-chip framing that freshness is a primary signal.

Follows up on #312 (POSTED sort comparator fixed) — now that the column actually sorts chronologically, it's safe to use it as the default.

## What

Three coordinated changes in \`docs/terminal/dashboard.jsx\`:

1. \`useState2\` initial \`sortKey\`: \`'deadline'\` → \`'posted'\` — the actual default.
2. F2 cycle order: \`['deadline','comp','co','posted']\` → \`['posted','deadline','comp','co']\` — so a single F2 press from the default advances to the *next* sort instead of cycling all the way back to where it started.
3. F1 HELP description: \`'cycle sort: deadline → comp → co → posted'\` → \`'cycle sort: posted → deadline → comp → co'\` — keeps the documentation honest.

Cache-bust \`?v=13\` → \`?v=14\` so existing visitors fetch the new bundle.

## Verification (local — \`python3 -m http.server 8765\` + Playwright)

| Check | Result |
|---|---|
| On fresh page load, which column header shows a sort arrow? | **POSTED ▲** only — no arrow on \`CO\`, \`COMP\`, or \`DEADLINE\` |
| Top rows of the table on fresh load | All \`now\` jobs — Samsara Data Engineer II, Samsara Field Sales Engineer II, … |
| Console errors before / after | 0 / 0 |