### PR TITLE
feat(ui): drop SEL slug, make SAVED count a click-to-filter chip (#314)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -61,15 +61,15 @@
   </div>
 
   <!-- Pure-JS helper for the LIVE chip, loadable in Node for unit testing. -->
-  <script src="terminal/live-stamp-format.js?v=14"></script>
+  <script src="terminal/live-stamp-format.js?v=15"></script>
 
   <!-- Cache-bust the bundle when its shape changes. Bump v= on data-shape edits. -->
-  <script type="text/babel" src="terminal/data.jsx?v=14"></script>
-  <script type="text/babel" src="terminal/contributors-data.jsx?v=14"></script>
-  <script type="text/babel" src="terminal/dashboard.jsx?v=14"></script>
-  <script type="text/babel" src="terminal/contributors.jsx?v=14"></script>
-  <script type="text/babel" src="terminal/live-stamp.jsx?v=14"></script>
-  <script type="text/babel" src="terminal/app.jsx?v=14"></script>
+  <script type="text/babel" src="terminal/data.jsx?v=15"></script>
+  <script type="text/babel" src="terminal/contributors-data.jsx?v=15"></script>
+  <script type="text/babel" src="terminal/dashboard.jsx?v=15"></script>
+  <script type="text/babel" src="terminal/contributors.jsx?v=15"></script>
+  <script type="text/babel" src="terminal/live-stamp.jsx?v=15"></script>
+  <script type="text/babel" src="terminal/app.jsx?v=15"></script>
 
   <script type="text/babel">
     (async () => {

--- a/docs/terminal/dashboard.jsx
+++ b/docs/terminal/dashboard.jsx
@@ -27,7 +27,12 @@ function DashboardDirection() {
   const [sortKey, setSortKey] = useState2('posted');
   const [sortDir, setSortDir] = useState2(1);
   const [selectedId, setSelectedId] = useState2(NGJOBS[5].id);
-  const [saved, setSaved] = useState2(new Set(['ant-mlr-26','crs-swe-26']));
+  // Saved-job IDs are user-driven (press S, or click the ☆ in a row). The
+  // previous seed (`['ant-mlr-26','crs-swe-26']`) was synthetic-mock cruft
+  // and never matched any real id in `docs/jobs.json`, so toggling the
+  // SAVED filter on a fresh load yielded `0 / N results`. Start empty.
+  const [saved, setSaved] = useState2(new Set());
+  const [savedOnly, setSavedOnly] = useState2(false);
   const [toast, setToast] = useState2(null);
   const [helpOpen, setHelpOpen] = useState2(false);
   const searchRef = useRef2(null);
@@ -52,6 +57,7 @@ function DashboardDirection() {
   // after picking one.
   const preCompanyFiltered = useMemo2(() => {
     return NGJOBS.filter(j => {
+      if (savedOnly && !saved.has(j.id)) return false;
       if (filters.type.size && !filters.type.has(j.type)) return false;
       if (filters.rmt.size && !filters.rmt.has(j.rmt)) return false;
       if (filters.visa !== null && j.visa !== filters.visa) return false;
@@ -63,7 +69,7 @@ function DashboardDirection() {
       }
       return true;
     });
-  }, [filters.type, filters.rmt, filters.visa, filters.cohort, filters.size, q]);
+  }, [filters.type, filters.rmt, filters.visa, filters.cohort, filters.size, q, savedOnly, saved]);
 
   const filtered = useMemo2(() => {
     let out = filters.company.size
@@ -406,8 +412,35 @@ function DashboardDirection() {
       }}>
         <span>STATUS: <span style={{ color: BBG.ok }}>OK</span></span>
         <span>QUERY: <span style={{ color: BBG.ink }}>{filtered.length}</span></span>
-        <span>SAVED: <span style={{ color: BBG.acc }}>{saved.size}</span></span>
-        <span>SEL: <span style={{ color: BBG.ink }}>{selected ? selected.id : '—'}</span></span>
+        <span
+          role="button"
+          tabIndex={0}
+          aria-pressed={savedOnly}
+          title={savedOnly
+            ? 'showing only saved jobs — click to clear'
+            : (saved.size ? `show only your ${saved.size} saved job${saved.size === 1 ? '' : 's'}` : 'no saved jobs yet')}
+          onClick={() => {
+            if (saved.size === 0) { flashToast('no saved jobs', BBG.warn); return; }
+            setSavedOnly(v => !v);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              if (saved.size === 0) { flashToast('no saved jobs', BBG.warn); return; }
+              setSavedOnly(v => !v);
+            }
+          }}
+          style={{
+            cursor: 'pointer',
+            padding: '0 4px',
+            background: savedOnly ? BBG.acc : 'transparent',
+            color: savedOnly ? '#000' : BBG.dim,
+            fontWeight: savedOnly ? 700 : 400,
+            transition: 'background 120ms ease',
+          }}
+        >
+          SAVED: <span style={{ color: savedOnly ? '#000' : BBG.acc, fontWeight: 700 }}>{saved.size}</span>
+        </span>
         <span style={{ marginLeft: 'auto', display: 'flex', gap: 14 }}>
           <FKey n="/"   l="SEARCH" />
           <FKey n="↑↓"  l="NAV" />


### PR DESCRIPTION
Closes #314.

## Why

Two coupled status-bar problems on the dashboard:

1. **\`SEL: <slug>\` was noise.** The selected job is already highlighted in the center table and its full detail renders in the right panel. The status bar was just duplicating the (very long, kebab-case) job id.

2. **\`SAVED: N\` was a passive counter.** Everything else in this terminal UI is interactive — having a dead readout for the user's saved jobs felt like a missed affordance. Clicking it to filter the table to *only* saved jobs is the obvious move.

3. **Bonus, surfaced during testing:** the previous synthetic seed for \`saved\` (\`['ant-mlr-26','crs-swe-26']\`) never matched any real id in \`docs/jobs.json\`. Toggling the saved-only filter on a fresh load gave \`0 / N results\` and felt broken.

## What

\`docs/terminal/dashboard.jsx\`:

- Removed the \`<span>SEL: …</span>\`.
- Added \`savedOnly\` boolean state.
- \`preCompanyFiltered\` now excludes any job whose id isn't in \`saved\` when \`savedOnly === true\`. Because \`coCounts\` derives from \`preCompanyFiltered\`, the HIRING NOW sidebar automatically collapses to just the companies the user has saved jobs from — which is exactly the cross-section they want.
- The \`SAVED: N\` span is now a \`role=\"button\"\` with \`aria-pressed\`, Enter/Space keyboard activation, and an inverted visual state when active (amber bg + black text + bold).
- Clicking with \`saved.size === 0\` flashes \`\"no saved jobs\"\` toast and is a no-op.
- Seed \`saved\` Set is now empty — the count climbs as the user actually saves jobs.

\`docs/index.html\`: cache-bust \`?v=14\` → \`?v=15\`.

## Verification (local — \`python3 -m http.server 8765\` + Playwright)

| Step | Expected | Actual |
|---|---|---|
| Fresh load | \`SEL:\` absent; status reads \`STATUS / QUERY / SAVED:0 / F-keys\`; SAVED chip \`aria-pressed=false\`, transparent bg | ✓ |
| Click SAVED with count=0 | toast \"no saved jobs\", no toggle | ✓ — \`aria-pressed\` stays false, results stay \`1361/1361\` |
| Click ☆ on a job row | count climbs to 1 | ✓ — \`SAVED: 1\` |
| Click SAVED with count=1 | results = 1/1361, chip active | ✓ — \`aria-pressed=true\`, bg \`rgb(255,157,61)\` |
| Click SAVED again | filter clears, chip inactive | ✓ — results \`1361/1361\`, \`aria-pressed=false\`, transparent bg |
| Console errors | 0 before, 0 after | ✓ |

Screenshot: \`saved-filter-off.png\` (post-clear state).

## Out of scope

- URL persistence of the saved-only filter.
- A separate \"saved\" tab — the toggle is enough.
- localStorage persistence of the saved Set across reloads — separate issue; the current Set is session-scoped by design.