### PR TITLE
feat: add Scout AI, SIXGEN, and Booz Allen Hamilton

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -313,10 +313,14 @@ apis:
         url: "https://boards-api.greenhouse.io/v1/boards/scaleai/jobs"
       - name: "Scopely"
         url: "https://boards-api.greenhouse.io/v1/boards/scopely/jobs"
+      - name: "Scout AI"
+        url: "https://boards-api.greenhouse.io/v1/boards/scoutai/jobs"
       - name: "SeatGeek"
         url: "https://boards-api.greenhouse.io/v1/boards/seatgeek/jobs"
       - name: "SingleStore"
         url: "https://boards-api.greenhouse.io/v1/boards/singlestore/jobs"
+      - name: "SIXGEN"
+        url: "https://boards-api.greenhouse.io/v1/boards/sixgeninc/jobs"
       - name: "SoFi"
         url: "https://boards-api.greenhouse.io/v1/boards/sofi/jobs"
       - name: "SpaceX"
@@ -931,6 +935,8 @@ apis:
         workday_url: "https://fil.wd1.myworkdayjobs.com/external"
 
       # --- Consulting & Professional Services ---
+      - name: "Booz Allen Hamilton"
+        workday_url: "https://bah.wd1.myworkdayjobs.com/BAH_Jobs"
       - name: "Deloitte"
         workday_url: "https://deloitte.wd1.myworkdayjobs.com/DeloitteCareers"
       - name: "PwC"


### PR DESCRIPTION
Closes #325

## Summary

Adds 3 companies from the 2268–2290 candidate batch after probing each entry against the ATSs the pipeline supports (Greenhouse, Lever, Ashby, Workday).

| Company | ATS | Slug / Path | Jobs |
|---------|-----|-------------|-----:|
| Scout AI | Greenhouse | `scoutai` | 23 |
| SIXGEN | Greenhouse | `sixgeninc` | 23 |
| Booz Allen Hamilton | Workday | `bah.wd1.myworkdayjobs.com/BAH_Jobs` | 1957 |

## Already present (skipped)

CACI International, Leidos (incl. Leidos Australia), Amazon (AWS), and x.ai / xAI are already in `config.yml`. No duplicates added.

## Intentionally not added

The following candidates were probed and have no working endpoint on a supported ATS. Left out per the "only add if working" rule:

ISI, Capital Insurance Group, City of Plano, Akima (uses iCIMS — not wired in), Mayo Clinic (research fellowship, not corporate ATS), SchoolSpring (job-board marketplace), Authentic (ABG), Mutual of Omaha (JS-rendered SPA), Notability / Ginger Labs, Quest Global, Cecil College, New York University, The Vermont Country Store.

See #325 for full per-candidate rationale.

## Change

Single-file edit to `config.yml`:
- 2 lines under `apis.greenhouse.companies` (Scout AI, SIXGEN — alphabetically placed)
- 1 line under `apis.workday.companies` → Consulting & Professional Services group (Booz Allen Hamilton)

Net diff: `+6 lines`.

## Test plan

- [x] `python scripts/validate_config.py` — 281 companies, all sections load
- [x] Duplicate-URL guard — 281 unique URLs, none duplicated
- [x] `pytest tests/` — 733 passed locally
- [ ] CI green on this PR

## Endpoint verification

```
curl https://boards-api.greenhouse.io/v1/boards/scoutai/jobs                   -> 200, 23 jobs
curl https://boards-api.greenhouse.io/v1/boards/sixgeninc/jobs                 -> 200, 23 jobs
POST https://bah.wd1.myworkdayjobs.com/wday/cxs/bah/BAH_Jobs/jobs (Workday)    -> 200, total=1957
```