### PR TITLE
fix(security): 2 improvements across 1 files

### DIFF
--- a/.github/scripts/verify_new_urls.py
+++ b/.github/scripts/verify_new_urls.py
@@ -9,16 +9,33 @@ sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
 from scripts.update_jobs import create_optimized_session
 
 
+# Match a config URL key and capture its https?:// value on an added diff line.
+#   ^\+                 -> only added lines
+#   (?:(?!#).)*?        -> lazily skip prefix, but never cross a '#' so commented
+#                          lines like `+ # url: "..."` are ignored
+#   (?<![\w-])          -> require a key boundary so `callback_url:` / `source_url:`
+#                          do NOT match, only `url:` / `workday_url:` / `endpoint:`
+#   ["\']?              -> quotes are optional (YAML allows unquoted scalars)
+#   (https?://[^\s"'#]+) -> the URL, stopping at whitespace, quote, or '#' fragment
+_NEW_URL_RE = re.compile(
+    r'^\+(?:(?!#).)*?(?<![\w-])(?:url|workday_url|endpoint):\s*["\']?\s*(https?://[^\s"\'#]+)'
+)
+
+
 def get_new_urls_from_diff(diff_text):
     """
     Extracts URLs that are literally added (lines starting with +) in config.yml.
+
+    Handles quoted and unquoted values, ignores commented-out lines, and only
+    matches the intended config keys (not similarly named keys such as
+    ``callback_url`` or ``source_url``).
     """
     urls = []
-    # Only look at added lines that aren't diff headers
-    added_lines = [line for line in diff_text.splitlines() if line.startswith('+') and not line.startswith('+++')]
-
-    for line in added_lines:
-        match = re.search(r'(?:url|workday_url|endpoint):\s*["\']\s*(https?://[^"\']+)["\']', line)
+    for line in diff_text.splitlines():
+        # Skip diff headers; only consider added lines.
+        if not line.startswith('+') or line.startswith('+++'):
+            continue
+        match = _NEW_URL_RE.search(line)
         if match:
             urls.append(match.group(1).strip())
 

--- a/.github/scripts/verify_new_urls.py
+++ b/.github/scripts/verify_new_urls.py
@@ -18,8 +18,7 @@ def get_new_urls_from_diff(diff_text):
     added_lines = [line for line in diff_text.splitlines() if line.startswith('+') and not line.startswith('+++')]
 
     for line in added_lines:
-        # Looking for: url: "https://..."
-        match = re.search(r'url:\s*["\']( https?://[^"\']+)["\']', line)
+        match = re.search(r'(?:url|workday_url|endpoint):\s*["\']\s*(https?://[^"\']+)["\']', line)
         if match:
             urls.append(match.group(1).strip())
 

--- a/tests/test_verify_new_urls.py
+++ b/tests/test_verify_new_urls.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Tests for the config URL extractor in .github/scripts/verify_new_urls.py.
+
+The script is the CI gate that verifies newly added ATS URLs in config.yml are
+reachable. These tests lock in the diff-parsing behaviour so the gate keeps
+matching the intended keys (and only those) across quoted, unquoted, and
+commented-out lines.
+"""
+
+import importlib.util
+import os
+
+import pytest
+
+_REPO_ROOT = os.path.join(os.path.dirname(__file__), '..')
+_MODULE_PATH = os.path.join(_REPO_ROOT, '.github', 'scripts', 'verify_new_urls.py')
+
+
+def _load_module():
+    """Load verify_new_urls.py by path (it lives outside the scripts/ package)."""
+    import sys
+
+    sys.path.insert(0, os.path.abspath(_REPO_ROOT))
+    spec = importlib.util.spec_from_file_location('verify_new_urls', _MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except Exception as exc:  # pragma: no cover - dependency import guard
+        pytest.skip(f"verify_new_urls could not be imported: {exc}")
+    return module
+
+
+verify_new_urls = _load_module()
+get_new_urls_from_diff = verify_new_urls.get_new_urls_from_diff
+
+
+def _diff(*lines):
+    return "\n".join(lines)
+
+
+def test_matches_standard_quoted_url():
+    diff = _diff('+        url: "https://boards.greenhouse.io/acme"')
+    assert get_new_urls_from_diff(diff) == ['https://boards.greenhouse.io/acme']
+
+
+def test_matches_single_quoted_url():
+    diff = _diff("+        url: 'https://jobs.lever.co/acme'")
+    assert get_new_urls_from_diff(diff) == ['https://jobs.lever.co/acme']
+
+
+def test_matches_unquoted_yaml_url():
+    """YAML allows unquoted scalars; the gate must still verify them."""
+    diff = _diff('+        url: https://unquoted.example.com')
+    assert get_new_urls_from_diff(diff) == ['https://unquoted.example.com']
+
+
+def test_matches_workday_and_endpoint_keys():
+    diff = _diff(
+        '+        workday_url: "https://acme.wd1.myworkdayjobs.com/x"',
+        '+        endpoint: "https://api.example.com/graphql"',
+    )
+    assert set(get_new_urls_from_diff(diff)) == {
+        'https://acme.wd1.myworkdayjobs.com/x',
+        'https://api.example.com/graphql',
+    }
+
+
+def test_matches_url_with_no_space_after_quote():
+    """Regression for the original bug: the old regex required a literal space."""
+    diff = _diff('+        url: "https://no-space.example.com"')
+    assert get_new_urls_from_diff(diff) == ['https://no-space.example.com']
+
+
+@pytest.mark.parametrize('key', ['callback_url', 'source_url', 'redirect_url'])
+def test_ignores_similarly_named_keys(key):
+    """Keys that merely end in `url` must not be treated as ATS URL fields."""
+    diff = _diff(f'+        {key}: "https://not-an-ats.example.com"')
+    assert get_new_urls_from_diff(diff) == []
+
+
+def test_ignores_commented_out_lines():
+    diff = _diff('+        # url: "https://malicious.example.com"')
+    assert get_new_urls_from_diff(diff) == []
+
+
+def test_ignores_context_and_removed_lines():
+    diff = _diff(
+        '         url: "https://context.example.com"',
+        '-        url: "https://removed.example.com"',
+        '+++ b/config.yml',
+    )
+    assert get_new_urls_from_diff(diff) == []
+
+
+def test_deduplicates_repeated_urls():
+    diff = _diff(
+        '+        url: "https://dup.example.com"',
+        '+        url: "https://dup.example.com"',
+    )
+    assert get_new_urls_from_diff(diff) == ['https://dup.example.com']


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 1 files

## Problem

**Severity**: `High` | **File**: `.github/scripts/verify_new_urls.py:L22`

verify_new_urls.py is the PR gate for new ATS URLs but is ineffective. Regex requires a literal space after the opening quote (`["']( https?://`), so normal `url: "https://..."` lines never match. Pattern only matches `url:`, not `workday_url:` or GraphQL `endpoint:`. Malicious or dead URLs can land in config.yml without CI checks.

## Solution

Use `r'(?:url|workday_url|endpoint):\s*["\']\s*(https?://[^"']+)["\']'`. Strip capture. Cover all config URL keys. Add unit tests for no-space quotes and workday/graphql keys.

## Changes

- `.github/scripts/verify_new_urls.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
_Note: this change was drafted with AI assistance and reviewed locally before submission._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved URL validation to correctly detect newly added HTTPS URLs.
  - Added support for additional URL configuration fields.
  - Fixed extraction to prevent leading whitespace from being included in captured URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->