### PR TITLE
fix: resolve #133 — [Good First Issue]: align ci.yml config validation with current config["apis"] schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,14 +61,14 @@ jobs:
           import yaml, sys
           with open("config.yml") as f:
               config = yaml.safe_load(f)
-          required_keys = ["filtering", "readme"]
+          required_keys = ["filtering", "apis", "readme"]
           for key in required_keys:
               if key not in config:
                   print(f"ERROR: Missing required top-level key in config.yml: '{key}'")
                   sys.exit(1)
           print(f"✅ config.yml is valid YAML with all required keys.")
-          greenhouse = config.get("greenhouse", {}).get("companies", [])
-          lever = config.get("lever", {}).get("companies", [])
+          greenhouse = config.get("apis", {}).get("greenhouse", {}).get("companies", [])
+          lever = config.get("apis", {}).get("lever", {}).get("companies", [])
           print(f"   Greenhouse companies: {len(greenhouse)}")
           print(f"   Lever companies: {len(lever)}")
           EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,20 @@ jobs:
                   print(f"ERROR: Missing required top-level key in config.yml: '{key}'")
                   sys.exit(1)
           print(f"✅ config.yml is valid YAML with all required keys.")
-          greenhouse = config.get("apis", {}).get("greenhouse", {}).get("companies", [])
-          lever = config.get("apis", {}).get("lever", {}).get("companies", [])
+          # Read nested company lists directly so a missing or malformed
+          # apis.greenhouse.companies / apis.lever.companies schema fails loudly
+          # instead of silently reporting zero companies.
+          try:
+              apis = config["apis"]
+              greenhouse = apis["greenhouse"]["companies"]
+              lever = apis["lever"]["companies"]
+          except (KeyError, TypeError):
+              print("ERROR: Invalid nested API schema in config.yml "
+                    "(expected apis.greenhouse.companies and apis.lever.companies)")
+              sys.exit(1)
+          if not isinstance(greenhouse, list) or not isinstance(lever, list):
+              print("ERROR: apis.greenhouse.companies and apis.lever.companies must be lists")
+              sys.exit(1)
           print(f"   Greenhouse companies: {len(greenhouse)}")
           print(f"   Lever companies: {len(lever)}")
           EOF


### PR DESCRIPTION
## Summary

fix: resolve #133 — [Good First Issue]: align ci.yml config validation with current config["apis"] schema

## Problem

**Severity**: `Low` | **File**: `.github/workflows/ci.yml`

Validate config.yml step reads greenhouse/lever from top-level keys. Schema nests them under config["apis"]. Counts wrong; nested schema unchecked.

## Solution

In Validate config.yml structure step: require top-level keys filtering, apis, readme. Read counts from config["apis"]["greenhouse"]["companies"] and config["apis"]["lever"]["companies"]. Fail only on missing required keys/schema. Keep log output clear.

## Changes

- `.github/workflows/ci.yml` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
_Note: this change was drafted with AI assistance and reviewed locally before submission._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration validation to require the `apis` section.
  * Improved validation reporting for Greenhouse and Lever company lists by using their configured API settings.
  * CI checks now better reflect the current configuration structure and provide more accurate company counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->