### PR TITLE
fix: resolve #51 — [Beginner]: Add an `.editorconfig` file to standardize code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.py]
+[*.{py,toml}]
 indent_style = space
 indent_size = 4
 


### PR DESCRIPTION
## Summary

fix: resolve #51 — [Beginner]: Add an `.editorconfig` file to standardize code formatting

## Problem

**Severity**: `Low` | **File**: `.editorconfig`

New root `.editorconfig` so IDEs auto-apply consistent indent, charset, trailing-whitespace trim, and final newlines before pre-commit. Covers Python (4 spaces), YAML/JSON (2 spaces), and Markdown as required by the issue.

## Solution

Create `.editorconfig` at repo root with:

## Changes

- `.editorconfig` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
_Note: this change was drafted with AI assistance and reviewed locally before submission._