### PR TITLE
fix: resolve #49 — [Beginner]: Make `normalize_date_string` accept an optional `reference_date` parameter

### DIFF
--- a/scripts/update_jobs.py
+++ b/scripts/update_jobs.py
@@ -2199,10 +2199,21 @@ def has_track_signal(title: str, signals: List[str]) -> bool:
 
     return False
 
-def normalize_date_string(posted_at: Any, now_utc: datetime | None = None) -> str:
+def normalize_date_string(
+    posted_at: Any,
+    reference_date: datetime | None = None,
+    *,
+    now_utc: datetime | None = None,
+) -> str:
     """
     Normalize human-readable date strings from JobSpy/LinkedIn/Indeed/Glassdoor
     to ISO format dates that date_parser can handle.
+
+    ``reference_date`` is the "current time" used to resolve relative phrases such
+    as "today", "yesterday", or "2 days ago". Injecting it makes the function
+    deterministic and eliminates flaky tests around midnight boundaries; it
+    defaults to ``datetime.now(timezone.utc)`` when omitted. ``now_utc`` is kept
+    as a backward-compatible keyword alias for existing call sites.
 
     Handles formats like:
     - "Posted Today" -> today's date
@@ -2229,9 +2240,10 @@ def normalize_date_string(posted_at: Any, now_utc: datetime | None = None) -> st
         return str(posted_at)
 
     posted_at_lower = posted_at.lower().strip()
-    if now_utc is None:
-        now_utc = datetime.now(timezone.utc)
-    now = now_utc.replace(tzinfo=None)
+    reference = reference_date if reference_date is not None else now_utc
+    if reference is None:
+        reference = datetime.now(timezone.utc)
+    now = reference.replace(tzinfo=None)
 
     # Handle "Posted Today" or "Today"
     if 'today' in posted_at_lower:

--- a/tests/test_date_normalization.py
+++ b/tests/test_date_normalization.py
@@ -43,6 +43,13 @@ def test_normalize_date_string_jobspy_human_readable_variants():
     assert normalize_date_string('1 minute ago', FIXED_NOW_UTC) == now.strftime('%Y-%m-%d')
 
 
+def test_normalize_date_string_fixed_reference_date_relative_phrases():
+    ref = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+    assert normalize_date_string('today', ref) == '2024-06-15'
+    assert normalize_date_string('yesterday', ref) == '2024-06-14'
+    assert normalize_date_string('2 days ago', ref) == '2024-06-13'
+
+
 def test_normalize_date_string_hours_ago():
     """'X hours ago' and 'X hour ago' resolve to today's date."""
     now = FIXED_NOW_UTC.replace(tzinfo=None)

--- a/tests/test_date_normalization.py
+++ b/tests/test_date_normalization.py
@@ -50,6 +50,25 @@ def test_normalize_date_string_fixed_reference_date_relative_phrases():
     assert normalize_date_string('2 days ago', ref) == '2024-06-13'
 
 
+def test_normalize_date_string_reference_date_keyword():
+    """The `reference_date` keyword (issue #49) resolves relative phrases."""
+    ref = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+    assert normalize_date_string('today', reference_date=ref) == '2024-06-15'
+    assert normalize_date_string('3 days ago', reference_date=ref) == '2024-06-12'
+
+
+def test_normalize_date_string_now_utc_alias_still_works():
+    """`now_utc` remains a backward-compatible alias for existing callers."""
+    ref = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+    assert normalize_date_string('yesterday', now_utc=ref) == '2024-06-14'
+
+
+def test_normalize_date_string_reference_date_takes_precedence_over_now_utc():
+    ref = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+    other = datetime(2020, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    assert normalize_date_string('today', reference_date=ref, now_utc=other) == '2024-06-15'
+
+
 def test_normalize_date_string_hours_ago():
     """'X hours ago' and 'X hour ago' resolve to today's date."""
     now = FIXED_NOW_UTC.replace(tzinfo=None)


### PR DESCRIPTION
## Summary

fix: resolve #49 — [Beginner]: Make `normalize_date_string` accept an optional `reference_date` parameter

## Problem

**Severity**: `Medium` | **File**: `tests/test_date_normalization.py`

Existing tests may be flaky or incomplete around day boundaries. Add/adjust cases that pass a fixed `reference_date` so relative phrases ("today", "yesterday", "2 days ago") resolve deterministically.

## Solution

Import `datetime`/`timezone` as needed. Add cases like: fixed `reference_date=datetime(2024, 6, 15, 12, 0, 0)` with inputs "today"/"yesterday"/relative strings; assert exact normalized output. Keep old tests (they still pass via default `None`). One assert-based check or pytest case is enough. Run `pre-commit run --all-files` after.

## Changes

- `tests/test_date_normalization.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
_Note: this change was drafted with AI assistance and reviewed locally before submission._