### PR TITLE
fix: resolve #245 — [Feature]: add publish-time URL safety validation for jobs artifact output

### DIFF
--- a/scripts/update_jobs.py
+++ b/scripts/update_jobs.py
@@ -44,6 +44,11 @@ except ModuleNotFoundError:
     # Supports import-by-path checks that load scripts/update_jobs.py directly.
     from scripts.source_cooldown import SOURCE_COOLDOWN, SOURCE_COOLDOWN_THRESHOLD, SourceCooldownTracker
 
+try:
+    from url_safety import filter_safe_jobs
+except ModuleNotFoundError:
+    from scripts.url_safety import filter_safe_jobs
+
 # Worker pool configuration constants
 # These default values act as fallback constants. The active pool sizes
 # are read from config.yml under 'worker_pools' during startup.
@@ -3083,13 +3088,19 @@ def _compute_display_metrics(
 def generate_health_json(jobs: List[Dict[str, Any]],
                          source_counts: Dict[str, int],
                          start_time: float,
-                         config: Dict[str, Any]) -> None:
+                         config: Dict[str, Any],
+                         url_blocked_count: int = 0) -> None:
     """Generate docs/health.json for monitoring and staleness detection.
 
     Status values:
       - ok: all sources returned jobs and total > 0
-      - degraded: at least one source returned 0 jobs
+      - degraded: at least one source returned 0 jobs, or the publish-time URL
+        safety gate blocked one or more jobs
       - failed: total job count is 0
+
+    ``url_blocked_count`` is the number of jobs dropped by the publish-time URL
+    safety gate (see scripts/url_safety.py); it is surfaced as telemetry so
+    monitoring can alert when unsafe links start appearing upstream.
     """
     health_path = os.path.join(os.path.dirname(__file__), '..', 'docs', 'health.json')
 
@@ -3098,7 +3109,7 @@ def generate_health_json(jobs: List[Dict[str, Any]],
 
     if total_jobs == 0:
         status = 'failed'
-    elif zero_sources:
+    elif zero_sources or url_blocked_count:
         status = 'degraded'
     else:
         status = 'ok'
@@ -3111,6 +3122,7 @@ def generate_health_json(jobs: List[Dict[str, Any]],
         'total_jobs': total_jobs,
         'source_counts': source_counts,
         'zero_sources': zero_sources,
+        'url_safety_blocked': url_blocked_count,
         'run_duration_seconds': round(time.time() - start_time, 1),
         **display_metrics,
     }
@@ -3392,6 +3404,16 @@ def main():
 
     enriched_jobs = deep_sanitize(enriched_jobs)
 
+    # ========== Publish-time URL safety gate ==========
+    # Final guard before anything is written to the public docs/jobs.json:
+    # drop any job whose URL is not a public http(s) link (non-http schemes,
+    # localhost/private/metadata targets, malformed hosts). See scripts/url_safety.py.
+    enriched_jobs, url_blocked_count, url_blocked_samples = filter_safe_jobs(enriched_jobs)
+    if url_blocked_count:
+        print(f"🛡️  URL safety: blocked {url_blocked_count} job(s) with unsafe/missing URLs")
+        for sample in url_blocked_samples:
+            print(f"      • {sample}")
+
     jobs_json = generate_jobs_json(enriched_jobs, config)
 
     # ========== Save Historical Market Data ==========
@@ -3414,7 +3436,8 @@ def main():
     generate_rss_feed(enriched_jobs)
 
     # ========== Generate Health Report ==========
-    generate_health_json(enriched_jobs, source_counts, start_time, config)
+    generate_health_json(enriched_jobs, source_counts, start_time, config,
+                         url_blocked_count=url_blocked_count)
 
     # ========== Sync README count tokens ==========
     # README.md remains a hand-edited document; only the digits inside

--- a/scripts/url_safety.py
+++ b/scripts/url_safety.py
@@ -1,9 +1,24 @@
-"""Publish-time URL safety checks (stdlib only)."""
+"""Publish-time URL safety checks (stdlib only).
+
+Every URL written into the public ``docs/jobs.json`` artifact must be a public
+``http``/``https`` link. This module rejects anything that could point a reader
+(or an automated fetcher) at an internal target:
+
+* non-``http(s)`` schemes,
+* ``localhost`` and private-use TLDs (``.local``, ``.internal``, ``.test`` …),
+* private / loopback / link-local / reserved / multicast IPs — including the
+  integer, hex, and octal encodings that browsers silently accept,
+* cloud metadata endpoints (``169.254.169.254``, Alibaba ``100.100.100.200``),
+* malformed hosts (backslashes, embedded slashes, percent/zone characters,
+  bare single-label names).
+
+Pure standard library: ``urllib.parse`` + ``ipaddress``.
+"""
 
 from __future__ import annotations
 
 import ipaddress
-from typing import Any, Dict, List, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 from urllib.parse import urlparse
 
 _BLOCKED_HOSTS = frozenset(
@@ -16,10 +31,67 @@ _BLOCKED_HOSTS = frozenset(
     }
 )
 
+# TLDs reserved for private networks, testing, and documentation
+# (RFC 6761, RFC 8375, RFC 2606). None resolve to a public destination.
+_PRIVATE_TLDS = (
+    ".localhost",
+    ".local",
+    ".internal",
+    ".intranet",
+    ".lan",
+    ".corp",
+    ".home",
+    ".home.arpa",
+    ".test",
+    ".invalid",
+    ".example",
+)
+
+# Metadata IPs that must never be published even when the generic
+# private/link-local checks would otherwise let one through.
+_BLOCKED_IPS = frozenset(
+    {
+        ipaddress.ip_address("169.254.169.254"),  # AWS / Azure / GCP IMDS
+        ipaddress.ip_address("100.100.100.200"),  # Alibaba Cloud metadata
+    }
+)
+
+
+def _coerce_ip(host: str) -> Optional[ipaddress._BaseAddress]:
+    """Parse ``host`` as an IP address, including integer encodings.
+
+    ``urlparse`` leaves ``2130706433`` (decimal), ``0x7f000001`` (hex) and
+    ``017700000001`` (octal) as opaque hostnames, yet browsers and many HTTP
+    clients resolve all three to ``127.0.0.1``. Decode them explicitly so the
+    loopback/private checks below cannot be bypassed. Returns ``None`` when the
+    host is not any IP form.
+    """
+    try:
+        return ipaddress.ip_address(host)
+    except ValueError:
+        pass
+
+    value: Optional[int] = None
+    try:
+        if host.startswith(("0x", "0X")):
+            value = int(host, 16)
+        elif host.startswith(("0o", "0O")):
+            value = int(host, 8)
+        elif host.startswith("0") and len(host) > 1 and host.isdigit():
+            value = int(host, 8)  # leading-zero octal, e.g. 017700000001
+        elif host.isdigit():
+            value = int(host, 10)
+    except ValueError:
+        value = None
+
+    if value is None or value < 0 or value > 0xFFFFFFFF:
+        return None
+    return ipaddress.ip_address(value)
+
 
 def is_safe_url(url: object) -> bool:
-    """Return True iff url is a public http(s) URL safe to publish."""
-    if url is None or not isinstance(url, str):
+    """Return True iff ``url`` is a public http(s) URL safe to publish."""
+    if not isinstance(url, str):
         return False
     text = url.strip()
     if not text:
@@ -28,37 +100,46 @@ def is_safe_url(url: object) -> bool:
         parsed = urlparse(text)
     except Exception:
         return False
-    scheme = (parsed.scheme or "").lower()
-    if scheme not in ("http", "https"):
+    if (parsed.scheme or "").lower() not in ("http", "https"):
         return False
+
     host = parsed.hostname
     if host is None:
         return False
     host = host.strip().lower().rstrip(".")
     if not host:
         return False
-    if host in _BLOCKED_HOSTS or host.endswith(".localhost"):
+
+    # Backslashes, embedded slashes and percent/zone characters: many clients
+    # normalise "\" to "/", turning localhost\evil.com into a request to
+    # localhost. Reject any host containing them outright.
+    if "\\" in host or "/" in host or "%" in host:
         return False
-    if "%" in host:
+
+    if host in _BLOCKED_HOSTS:
         return False
-    try:
-        ip = ipaddress.ip_address(host)
-    except ValueError:
-        if host == "localhost" or "/" in host or host.startswith("."):
+    if any(host == tld[1:] or host.endswith(tld) for tld in _PRIVATE_TLDS):
+        return False
+
+    ip = _coerce_ip(host)
+    if ip is not None:
+        if ip.version == 6 and ip.ipv4_mapped is not None:
+            ip = ip.ipv4_mapped
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+            or ip in _BLOCKED_IPS
+        ):
             return False
         return True
-    if ip.version == 6 and ip.ipv4_mapped is not None:
-        ip = ip.ipv4_mapped
-    if (
-        ip.is_private
-        or ip.is_loopback
-        or ip.is_link_local
-        or ip.is_multicast
-        or ip.is_reserved
-        or ip.is_unspecified
-    ):
-        return False
-    if ip == ipaddress.ip_address("169.254.169.254"):
+
+    # Not an IP: require a dotted, public-looking hostname. Bare single-label
+    # names ("intranet") and leading-dot garbage are never public.
+    if host.startswith(".") or "." not in host:
         return False
     return True
 
@@ -75,7 +156,12 @@ def _job_urls(job: Dict[str, Any]) -> List[str]:
 def filter_safe_jobs(
     jobs: Sequence[Dict[str, Any]],
 ) -> Tuple[List[Dict[str, Any]], int, List[str]]:
-    """Split jobs into safe list; return (safe_jobs, blocked_count, blocked_samples)."""
+    """Split jobs into a safe list.
+
+    Returns ``(safe_jobs, blocked_count, blocked_samples)``. A job is blocked
+    when it is not a dict, exposes no URL field, or exposes any URL that fails
+    :func:`is_safe_url`.
+    """
     safe: List[Dict[str, Any]] = []
     blocked_count = 0
     blocked_samples: List[str] = []

--- a/scripts/url_safety.py
+++ b/scripts/url_safety.py
@@ -1,0 +1,102 @@
+"""Publish-time URL safety checks (stdlib only)."""
+
+from __future__ import annotations
+
+import ipaddress
+from typing import Any, Dict, List, Sequence, Tuple
+from urllib.parse import urlparse
+
+_BLOCKED_HOSTS = frozenset(
+    {
+        "localhost",
+        "metadata",
+        "metadata.google.internal",
+        "metadata.goog",
+        "instance-data",
+    }
+)
+
+
+def is_safe_url(url: object) -> bool:
+    """Return True iff url is a public http(s) URL safe to publish."""
+    if url is None or not isinstance(url, str):
+        return False
+    text = url.strip()
+    if not text:
+        return False
+    try:
+        parsed = urlparse(text)
+    except Exception:
+        return False
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in ("http", "https"):
+        return False
+    host = parsed.hostname
+    if host is None:
+        return False
+    host = host.strip().lower().rstrip(".")
+    if not host:
+        return False
+    if host in _BLOCKED_HOSTS or host.endswith(".localhost"):
+        return False
+    if "%" in host:
+        return False
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        if host == "localhost" or "/" in host or host.startswith("."):
+            return False
+        return True
+    if ip.version == 6 and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    if (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    ):
+        return False
+    if ip == ipaddress.ip_address("169.254.169.254"):
+        return False
+    return True
+
+
+def _job_urls(job: Dict[str, Any]) -> List[str]:
+    urls: List[str] = []
+    for key in ("url", "apply_url", "job_url", "link", "absolute_url"):
+        val = job.get(key)
+        if isinstance(val, str) and val.strip():
+            urls.append(val.strip())
+    return urls
+
+
+def filter_safe_jobs(
+    jobs: Sequence[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], int, List[str]]:
+    """Split jobs into safe list; return (safe_jobs, blocked_count, blocked_samples)."""
+    safe: List[Dict[str, Any]] = []
+    blocked_count = 0
+    blocked_samples: List[str] = []
+    max_samples = 10
+    for job in jobs:
+        if not isinstance(job, dict):
+            blocked_count += 1
+            if len(blocked_samples) < max_samples:
+                blocked_samples.append("<non-dict>")
+            continue
+        urls = _job_urls(job)
+        if not urls:
+            blocked_count += 1
+            if len(blocked_samples) < max_samples:
+                blocked_samples.append("<missing>")
+            continue
+        bad = next((u for u in urls if not is_safe_url(u)), None)
+        if bad is None:
+            safe.append(job)
+        else:
+            blocked_count += 1
+            if len(blocked_samples) < max_samples:
+                blocked_samples.append(bad[:200])
+    return safe, blocked_count, blocked_samples

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Tests for the publish-time URL safety gate (scripts/url_safety.py).
+
+The gate is the last guard before URLs are written into the public
+``docs/jobs.json`` artifact, so the emphasis here is on *not leaking* internal
+targets while never rejecting a legitimate ATS link.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
+
+from url_safety import filter_safe_jobs, is_safe_url
+
+
+# --------------------------------------------------------------------------- #
+# is_safe_url — must-allow (legitimate public ATS URLs)
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize('url', [
+    'https://boards.greenhouse.io/acme',
+    'https://job-boards.greenhouse.io/embed/job_app?token=1',
+    'https://jobs.lever.co/acme/abc-123',
+    'https://acme.wd1.myworkdayjobs.com/en-US/careers',
+    'http://careers.example.com/job/123',
+    'https://8x8.com/careers',            # digit-containing label must stay allowed
+    'https://api.example.co.uk/v1/jobs',
+])
+def test_public_urls_are_allowed(url):
+    assert is_safe_url(url) is True
+
+
+# --------------------------------------------------------------------------- #
+# is_safe_url — must-block (schemes, private/loopback, malformed)
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize('url', [
+    'ftp://example.com',
+    'javascript:alert(1)',
+    'file:///etc/passwd',
+    'http://localhost/',
+    'http://127.0.0.1/',
+    'http://10.0.0.1/',
+    'http://192.168.1.10/',
+    'http://172.16.5.4/',
+    'http://[::1]/',
+    'http://0.0.0.0/',
+    'http://169.254.169.254/latest/meta-data/',   # AWS/GCP/Azure IMDS
+    'http://100.100.100.200/',                     # Alibaba metadata
+    'http://metadata.google.internal/',
+    'http://intranet/',                            # bare single-label host
+])
+def test_unsafe_urls_are_blocked(url):
+    assert is_safe_url(url) is False
+
+
+# --------------------------------------------------------------------------- #
+# is_safe_url — regression tests for the specific bypasses found in review
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize('url', [
+    'http://localhost\\evil.example.com/',  # backslash normalised to '/' by clients
+    'http://2130706433/',                   # decimal encoding of 127.0.0.1
+    'http://0x7f000001/',                   # hex encoding of 127.0.0.1
+    'http://017700000001/',                 # octal encoding of 127.0.0.1
+    'http://foo.internal/',                 # private-use TLD
+    'http://db.local/',
+    'http://service.lan/',
+    'http://x.test/',
+])
+def test_known_bypasses_are_blocked(url):
+    assert is_safe_url(url) is False
+
+
+@pytest.mark.parametrize('value', [None, 123, '', '   ', b'https://x.com'])
+def test_non_string_and_empty_are_unsafe(value):
+    assert is_safe_url(value) is False
+
+
+# --------------------------------------------------------------------------- #
+# filter_safe_jobs
+# --------------------------------------------------------------------------- #
+def test_filter_keeps_safe_and_drops_unsafe():
+    jobs = [
+        {'title': 'a', 'url': 'https://boards.greenhouse.io/a'},
+        {'title': 'b', 'apply_url': 'http://127.0.0.1/b'},
+        {'title': 'c', 'job_url': 'https://jobs.lever.co/c'},
+        {'title': 'd'},                       # no URL field at all
+        'not-a-dict',                          # malformed entry
+    ]
+    safe, blocked, samples = filter_safe_jobs(jobs)
+    assert [j['title'] for j in safe] == ['a', 'c']
+    assert blocked == 3
+    assert '<missing>' in samples
+    assert '<non-dict>' in samples
+
+
+def test_filter_blocks_job_when_any_url_field_is_unsafe():
+    jobs = [{
+        'title': 'mixed',
+        'url': 'https://boards.greenhouse.io/ok',
+        'apply_url': 'http://169.254.169.254/',
+    }]
+    safe, blocked, _ = filter_safe_jobs(jobs)
+    assert safe == []
+    assert blocked == 1
+
+
+def test_filter_samples_are_capped():
+    jobs = [{'url': 'http://127.0.0.1/%d' % i} for i in range(25)]
+    _, blocked, samples = filter_safe_jobs(jobs)
+    assert blocked == 25
+    assert len(samples) == 10
+
+
+def test_filter_empty_input():
+    assert filter_safe_jobs([]) == ([], 0, [])


### PR DESCRIPTION
## Summary

fix: resolve #245 — [Feature]: add publish-time URL safety validation for jobs artifact output

## Problem

**Severity**: `High` | **File**: `scripts/url_safety.py`

New module enforcing strict URL safety before artifact write. Reject non-http(s) schemes, localhost, private/link-local/loopback IPs, cloud metadata endpoints (169.254.169.254), malformed hosts, empty/missing URLs. Pure stdlib: urllib.parse + ipaddress. Export `is_safe_url(url) -> bool` and `filter_safe_jobs(jobs) -> (safe_jobs, blocked_count, blocked_samples)`.

## Solution

```python

## Changes

- `scripts/url_safety.py` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
_Note: this change was drafted with AI assistance and reviewed locally before submission._