### PR TITLE
fix: reconcile job-category taxonomy across README and the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@
 
 🏗️ [Infrastructure & SRE](#infrastructure--sre) (<!-- COUNT:infrastructure_sre -->163<!-- /COUNT -->)
 
+📱 [Product Management](#product-management) (<!-- COUNT:product_management -->3<!-- /COUNT -->)
+
+📈 [Quantitative Finance](#quantitative-finance) (<!-- COUNT:quant_finance -->4<!-- /COUNT -->)
+
 🔧 [Hardware Engineering](#hardware-engineering) (<!-- COUNT:hardware -->14<!-- /COUNT -->)
 
 💼 [Other](#other) (<!-- COUNT:other -->141<!-- /COUNT -->)
@@ -887,6 +891,27 @@
 | 🔥 Northrop Grumman | DevOps Engineer | United States-Colorado-Colorado Springs | 1 day ago | [Apply](https://ngc.wd1.myworkdayjobs.com/job/United-States-Colorado-Colorado-Springs/DevOps-Engineer_R10225395) |
 | 🔥 Boeing | Product Security Engineer, Associate | USA - Hazelwood, MO | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---Hazelwood-MO/Product-Security-Engineer--Product-Security-Engineer-_JR2025488464) |
 | 🔥 Boeing | Product Security Engineer, Mid-Level | USA - Hazelwood, MO | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---Hazelwood-MO/Product-Security-Engineer--Product-Security-Engineer-_JR2025488469) |
+
+## 📱 Product Management New Grad Roles
+
+[Back to top](#-2026-new-grad-positions)
+
+| Company | Role | Location | Posted | Apply |
+|---------|------|----------|--------|-------|
+| MongoDB | Software Engineer 3, Voyage Control Plane | Palo Alto; Seattle | Today | [Apply](https://www.mongodb.com/careers/job/?gh_jid=8041664) |
+| Telus | AI Innovation Associate (Vibe Coder) - Channel Technology and Sales Strategy Team | Toronto, ON, CA | 1 day ago | [Apply](https://ca.indeed.com/viewjob?jk=c040cfa3243204f4) |
+| Cerebras | Hardware / Low Level Security Engineer | US and Canada Offices | 2026-06-23 | [Apply](https://jobs.ashbyhq.com/cerebras/4e706d0d-65a6-4a36-9ff3-b9e9da16a618) |
+
+## 📈 Quantitative Finance New Grad Roles
+
+[Back to top](#-2026-new-grad-positions)
+
+| Company | Role | Location | Posted | Apply |
+|---------|------|----------|--------|-------|
+| TD | Associate - Quant Engineering and Development | Toronto, ON, CA | 2 days ago | [Apply](https://ca.indeed.com/viewjob?jk=3da5343bd3e269a5) |
+| Palantir | Deployment Strategist, New Grad - Intel, US Government | Washington, D.C. | 2026-06-15 | [Apply](https://jobs.lever.co/palantir/5d8286d6-992a-404b-94af-99c173d40299) |
+| 🚀 SpaceX | Customer Support Associate, Bilingual - Ukrainian (Starlink) | Redmond, WA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8548098002?gh_jid=8548098002) |
+| 🚀 SpaceX | Customer Support Associate, Bilingual - Ukrainian (Starlink) | Bastrop, TX | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8548093002?gh_jid=8548093002) |
 
 ## 🔧 Hardware Engineering New Grad Roles
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -61,15 +61,15 @@
   </div>
 
   <!-- Pure-JS helper for the LIVE chip, loadable in Node for unit testing. -->
-  <script src="terminal/live-stamp-format.js?v=16"></script>
+  <script src="terminal/live-stamp-format.js?v=17"></script>
 
   <!-- Cache-bust the bundle when its shape changes. Bump v= on data-shape edits. -->
-  <script type="text/babel" src="terminal/data.jsx?v=16"></script>
-  <script type="text/babel" src="terminal/contributors-data.jsx?v=16"></script>
-  <script type="text/babel" src="terminal/dashboard.jsx?v=16"></script>
-  <script type="text/babel" src="terminal/contributors.jsx?v=16"></script>
-  <script type="text/babel" src="terminal/live-stamp.jsx?v=16"></script>
-  <script type="text/babel" src="terminal/app.jsx?v=16"></script>
+  <script type="text/babel" src="terminal/data.jsx?v=17"></script>
+  <script type="text/babel" src="terminal/contributors-data.jsx?v=17"></script>
+  <script type="text/babel" src="terminal/dashboard.jsx?v=17"></script>
+  <script type="text/babel" src="terminal/contributors.jsx?v=17"></script>
+  <script type="text/babel" src="terminal/live-stamp.jsx?v=17"></script>
+  <script type="text/babel" src="terminal/app.jsx?v=17"></script>
 
   <script type="text/babel">
     (async () => {

--- a/docs/terminal/dashboard.jsx
+++ b/docs/terminal/dashboard.jsx
@@ -182,7 +182,7 @@ function DashboardDirection() {
         {/* ─ Left rail: filters as compact chip list ─ */}
         <div style={{ borderRight: `1px solid ${BBG.rule2}`, overflow: 'auto' }}>
           <ChipGroup title="ROLE">
-            {['SWE','ML','DATA','FE','BE','INFRA','SEC','MOBILE','HW'].map(t => (
+            {['SWE','ML','DATA','INFRA','PM','QUANT','HW','OTHER'].map(t => (
               <Chip key={t} on={filters.type.has(t)} onClick={() => toggleSet('type', t)} label={TYPE_LABEL[t]} />
             ))}
           </ChipGroup>

--- a/docs/terminal/data.jsx
+++ b/docs/terminal/data.jsx
@@ -6,7 +6,10 @@
 //                    fmtComp, daysLeft, deadlineLabel, deadlineHot,
 //                    NGJOBS_READY (Promise that resolves once jobs are loaded).
 
-const TYPE_LABEL = { SWE:'swe', ML:'ml', DATA:'data', FE:'frontend', BE:'backend', INFRA:'infra', SEC:'security', MOBILE:'mobile', HW:'hardware' };
+// Canonical job categories — the single source of truth shared with
+// scripts/update_jobs.py (CATEGORY_PATTERNS), docs/jobs.json (meta.categories),
+// and the README. Keep these ids/order in step with CATEGORY_TYPE below.
+const TYPE_LABEL = { SWE:'swe', ML:'ml', DATA:'data', INFRA:'infra', PM:'product', QUANT:'quant', HW:'hardware', OTHER:'other' };
 const SIZE_LABEL = { S:'<50', M:'50–500', L:'500–5k', XL:'5k+' };
 const RMT_LABEL  = { remote:'remote', hybrid:'hybrid', onsite:'onsite' };
 
@@ -31,40 +34,24 @@ function deadlineHot(dl) { return daysLeft(dl) <= 14; }
 
 // ── Mapping helpers ──────────────────────────────────────────────────────
 
+// Canonical category id (from jobs.json `job.category.id`) → short type code.
+// This is the ONLY source of the terminal's type column/filters, so the site
+// stays in step with docs/jobs.json meta.categories and the README rather than
+// re-deriving a separate taxonomy from job titles.
 const CATEGORY_TYPE = {
   software_engineering: 'SWE',
   data_ml:              'ML',
   data_engineering:     'DATA',
   infrastructure_sre:   'INFRA',
+  product_management:   'PM',
+  quant_finance:        'QUANT',
   hardware:             'HW',
-  other:                'SWE',
+  other:                'OTHER',
 };
 
-// Title-pattern matches that beat the (coarse) category mapping.  Pattern
-// order matters: HW before INFRA so "embedded systems engineer" wins HW;
-// SEC before INFRA so "cloud security engineer" wins SEC; ML before DATA
-// so "ML platform engineer" wins ML; MOBILE before FE so "mobile/iOS web"
-// goes to MOBILE.  Tested against the live 1134-job scrape:
-//   INFRA 184, SEC 130, DATA 79, ML 52, BE 43, HW 29, MOBILE 11, FE 8
-// The remaining ~629 jobs fall through to CATEGORY_TYPE (mostly SWE).
-const _TYPE_TITLE_PATTERNS = [
-  ['HW',     /\b(firmware|asic|fpga|silicon|chip design|rtl|verilog|embedded|hardware engineer)\b/i],
-  ['SEC',    /\b(security engineer|infosec|appsec|cyber\s?security|application security|cloud security|penetration)\b/i],
-  ['ML',     /\b(machine learning|ml engineer|ml research|ai engineer|ai research|deep learning|research engineer|nlp engineer|computer vision)\b/i],
-  ['DATA',   /\b(data scientist|data engineer|data analyst|analytics engineer|business intelligence)\b/i],
-  ['MOBILE', /\b(mobile|ios|android)\b/i],
-  ['FE',     /\b(front[\s-]?end|frontend|ui engineer|web engineer)\b/i],
-  ['BE',     /\b(back[\s-]?end|backend|server[\s-]?side)\b/i],
-  ['INFRA',  /\b(infrastructure|\bsre\b|site reliability|devops|platform engineer|reliability engineer|kubernetes|cloud engineer|distributed systems|systems engineer)\b/i],
-];
-
 function deriveType(j) {
-  const title = j.title || '';
-  for (const [type, pat] of _TYPE_TITLE_PATTERNS) {
-    if (pat.test(title)) return type;
-  }
   const catId = (j.category || {}).id || 'other';
-  return CATEGORY_TYPE[catId] || 'SWE';
+  return CATEGORY_TYPE[catId] || 'OTHER';
 }
 
 const TIER_SIZE = {

--- a/tests/test_category_taxonomy_sync.py
+++ b/tests/test_category_taxonomy_sync.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Guard that the job-category taxonomy stays in sync across every surface.
+
+The scraper's ``CATEGORY_PATTERNS`` (scripts/update_jobs.py) is the single
+source of truth. These tests fail if the README count markers or the terminal
+website (docs/terminal/*.jsx) drift away from it — the exact bug where
+``product_management`` and ``quant_finance`` existed in the data but were
+missing from the README and were silently folded into ``SWE`` on the site.
+"""
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from update_jobs import CATEGORY_PATTERNS
+
+_REPO = os.path.join(os.path.dirname(__file__), "..")
+CANONICAL_IDS = set(CATEGORY_PATTERNS.keys())
+
+
+def _read(*parts):
+    with open(os.path.join(_REPO, *parts), encoding="utf-8") as f:
+        return f.read()
+
+
+def test_readme_has_a_count_marker_for_every_canonical_category():
+    readme = _read("README.md")
+    marker_ids = set(re.findall(r"<!--\s*COUNT:([a-z_]+)\s*-->", readme))
+    marker_ids.discard("total")
+    assert marker_ids == CANONICAL_IDS, (
+        f"README category markers out of sync with CATEGORY_PATTERNS.\n"
+        f"  missing from README: {sorted(CANONICAL_IDS - marker_ids)}\n"
+        f"  extra in README:     {sorted(marker_ids - CANONICAL_IDS)}"
+    )
+
+
+def test_terminal_category_type_matches_canonical_ids():
+    data_jsx = _read("docs", "terminal", "data.jsx")
+    block = re.search(r"const CATEGORY_TYPE\s*=\s*\{(.*?)\}", data_jsx, re.DOTALL)
+    assert block, "CATEGORY_TYPE object not found in data.jsx"
+    keys = set(re.findall(r"(\w+):\s*'[A-Z]+'", block.group(1)))
+    assert keys == CANONICAL_IDS, (
+        f"Terminal CATEGORY_TYPE keys out of sync with CATEGORY_PATTERNS.\n"
+        f"  missing on site: {sorted(CANONICAL_IDS - keys)}\n"
+        f"  extra on site:   {sorted(keys - CANONICAL_IDS)}"
+    )
+
+
+def test_terminal_type_codes_are_consistent_across_map_labels_and_chips():
+    data_jsx = _read("docs", "terminal", "data.jsx")
+    dashboard = _read("docs", "terminal", "dashboard.jsx")
+
+    cat_block = re.search(r"const CATEGORY_TYPE\s*=\s*\{(.*?)\}", data_jsx, re.DOTALL).group(1)
+    code_values = set(re.findall(r":\s*'([A-Z]+)'", cat_block))
+
+    label_block = re.search(r"const TYPE_LABEL\s*=\s*\{(.*?)\}", data_jsx, re.DOTALL).group(1)
+    label_codes = set(re.findall(r"(\w+)\s*:", label_block))
+
+    chip_block = re.search(r"\[((?:'[A-Z]+',?\s*)+)\]\.map\(t =>", dashboard).group(1)
+    chip_codes = set(re.findall(r"'([A-Z]+)'", chip_block))
+
+    assert code_values == label_codes, (
+        f"TYPE_LABEL codes != CATEGORY_TYPE codes: "
+        f"{code_values ^ label_codes}"
+    )
+    assert code_values == chip_codes, (
+        f"dashboard filter chips != CATEGORY_TYPE codes: "
+        f"{code_values ^ chip_codes}"
+    )
+
+
+def test_no_legacy_title_derived_types_remain():
+    """The removed title-regex types must not linger as filter chips."""
+    dashboard = _read("docs", "terminal", "dashboard.jsx")
+    chip_block = re.search(r"\[((?:'[A-Z]+',?\s*)+)\]\.map\(t =>", dashboard).group(1)
+    chip_codes = set(re.findall(r"'([A-Z]+)'", chip_block))
+    for legacy in ("FE", "BE", "SEC", "MOBILE"):
+        assert legacy not in chip_codes, f"legacy title-derived type {legacy!r} still present"


### PR DESCRIPTION
## Problem

The README and the live website disagreed on job categories:

- **README** listed only **6** categories — missing `product_management` (3) and `quant_finance` (4), which exist in `docs/jobs.json`'s `meta.categories`. `sync_readme_counts.py` silently skips ids without a marker, so the README's per-category counts summed to **1451, not 1458**.
- **The live terminal site** (`docs/terminal/`) derived its **own** taxonomy from job titles (`SWE/ML/DATA/FE/BE/INFRA/SEC/MOBILE/HW`) and its fallback map was missing `product_management`/`quant_finance`, folding them into `SWE`.
- (`docs/app.js`, the old UI that *did* read `meta.categories`, is dead code — no longer loaded by `index.html`.)

Result: three drifting taxonomies. Only the grand total (1458) happened to match.

## Fix — one canonical taxonomy

The scraper's `CATEGORY_PATTERNS` (8 categories) is the single source of truth. All surfaces now use it:

- **README**: added Product Management + Quantitative Finance nav entries, `COUNT` markers, and sections. Per-category counts now equal `jobs.json` `meta.categories` and sum to the total.
- **`docs/terminal/data.jsx`**: the type column/filters now come from the canonical `job.category.id` instead of title regex. Verified over the live 1458-job `jobs.json`: distribution matches meta exactly (SWE 952 · ML 156 · DATA 25 · INFRA 163 · PM 3 · QUANT 4 · HW 14 · OTHER 141).
- **`docs/terminal/dashboard.jsx`**: canonical 8-type filter chips.
- **`docs/index.html`**: cache-bust bumped to `v17`.
- **tests**: `test_category_taxonomy_sync.py` fails if README / the site / the scraper ever drift again.

## UX tradeoff (please confirm)

The site's filters change from 9 title-derived types to the canonical 8. This **removes** the `Frontend / Backend / Security / Mobile` sub-filters and **adds** `Product Management / Quant / Other`. If you'd rather keep the granular filters, the correct follow-up is to add those as real categories in the **scraper** so they flow outward consistently — happy to do that instead.

Full suite green (807 tests).