### PR TITLE
feat: add Frontend/Backend/Mobile/Security as first-class job categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,21 @@
 <!-- COUNTS:START - counts below are auto-synced from docs/jobs.json by scripts/sync_readme_counts.py -->
 ## 📂 Browse <!-- COUNT:total -->1458<!-- /COUNT --> Jobs by Category
 
-💻 [Software Engineering](#software-engineering) (<!-- COUNT:software_engineering -->952<!-- /COUNT -->)
+💻 [Software Engineering](#software-engineering) (<!-- COUNT:software_engineering -->861<!-- /COUNT -->)
 
-🤖 [Data Science & ML](#data-science--ml) (<!-- COUNT:data_ml -->156<!-- /COUNT -->)
+🎨 [Frontend Engineering](#frontend-engineering) (<!-- COUNT:frontend -->9<!-- /COUNT -->)
+
+⚙️ [Backend Engineering](#backend-engineering) (<!-- COUNT:backend -->32<!-- /COUNT -->)
+
+📲 [Mobile Engineering](#mobile-engineering) (<!-- COUNT:mobile -->11<!-- /COUNT -->)
+
+🔒 [Security Engineering](#security-engineering) (<!-- COUNT:security -->85<!-- /COUNT -->)
+
+🤖 [Data Science & ML](#data-science--ml) (<!-- COUNT:data_ml -->149<!-- /COUNT -->)
 
 📊 [Data Engineering](#data-engineering) (<!-- COUNT:data_engineering -->25<!-- /COUNT -->)
 
-🏗️ [Infrastructure & SRE](#infrastructure--sre) (<!-- COUNT:infrastructure_sre -->163<!-- /COUNT -->)
+🏗️ [Infrastructure & SRE](#infrastructure--sre) (<!-- COUNT:infrastructure_sre -->122<!-- /COUNT -->)
 
 📱 [Product Management](#product-management) (<!-- COUNT:product_management -->3<!-- /COUNT -->)
 
@@ -48,7 +56,7 @@
 
 🔧 [Hardware Engineering](#hardware-engineering) (<!-- COUNT:hardware -->14<!-- /COUNT -->)
 
-💼 [Other](#other) (<!-- COUNT:other -->141<!-- /COUNT -->)
+💼 [Other](#other) (<!-- COUNT:other -->143<!-- /COUNT -->)
 <!-- COUNTS:END -->
 
 ---
@@ -639,6 +647,106 @@
 | 🔥 Boeing | Systems Software Engineer | United States - Remote | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/United-States---Remote/Systems-Software-Engineer_JR2026496174-2) |
 | 🔥 Boeing | Entry-Level F-22 Software Engineer - Developer | USA - Berkeley, MO | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---Berkeley-MO/Entry-Level-F-22-Software-Engineer---Developer_JR2025474697-1) |
 | 🔥 Boeing | Spacecraft Systems Engineer (Experienced) - Millennium Space Systems | USA - El Segundo, CA | 1 day ago | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---El-Segundo-CA/Spacecraft-Systems-Engineer--Experienced----Millennium-Space-Systems_JR2026499500-2) |
+
+## 🎨 Frontend Engineering New Grad Roles
+
+[Back to top](#-2026-new-grad-positions)
+
+| Company | Role | Location | Posted | Apply |
+|---------|------|----------|--------|-------|
+| Anduril Industries | Frontend Software Engineer | Costa Mesa, California, United States | Today | [Apply](https://boards.greenhouse.io/andurilindustries/jobs/5147775007?gh_jid=5147775007) |
+| Anduril Industries | Mission Software Engineer, Air Vehicle Autonomy, Frontend | Costa Mesa, California, United States | Today | [Apply](https://boards.greenhouse.io/andurilindustries/jobs/4673956007?gh_jid=4673956007) |
+| Anduril Industries | Mission Software Engineer, Air Vehicle Autonomy, Frontend | Seattle, Washington, United States | Today | [Apply](https://boards.greenhouse.io/andurilindustries/jobs/4674088007?gh_jid=4674088007) |
+| 🚀 Twilio | Frontend Software Engineer | Remote - United Kingdom | Today | [Apply](https://job-boards.greenhouse.io/twilio/jobs/7946608) |
+| Focus Camera | Junior Full Stack Web Developer | Brooklyn, NY, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=758d36fedb1d720f) |
+| 🚀 Glean | Software Engineer, Frontend | Mountain View, CA | 2026-07-06 | [Apply](https://job-boards.greenhouse.io/gleanwork/jobs/4006733005) |
+| 🔥 Lyft | Software Engineer, Frontend - Lyft Urban Solutions | Toronto, Canada | 2026-07-06 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8594759002?gh_jid=8594759002) |
+| 🚀 Dropbox | Frontend Product Software Engineer, Design Systems | Remote - Mexico | 2026-07-02 | [Apply](https://jobs.dropbox.com/listing/7862086?gh_jid=7862086) |
+| 🚀 Airtable | Software Engineer, Product Frontend (8+ YOE) | San Francisco, CA; New York, NY | 2026-06-22 | [Apply](https://job-boards.greenhouse.io/airtable/jobs/8397228002) |
+
+## ⚙️ Backend Engineering New Grad Roles
+
+[Back to top](#-2026-new-grad-positions)
+
+| Company | Role | Location | Posted | Apply |
+|---------|------|----------|--------|-------|
+| 🚀 SpaceX | Backend Software Engineer, GNC (Starlink) | Redmond, WA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8398679002?gh_jid=8398679002) |
+| Anduril Industries | Mission Software Engineer, Air Vehicle Autonomy, Backend | Costa Mesa, California, United States; Seattle, Washington, United States; Washington, District of Columbia, United States | Today | [Apply](https://boards.greenhouse.io/andurilindustries/jobs/4672848007?gh_jid=4672848007) |
+| Sigtuple Technologies Private Limited | Software Engineer - Backend | KA, IN | Today | [Apply](https://in.indeed.com/viewjob?jk=a60ee9968aee1ef3) |
+| 🚀 Affirm | Software Engineer II, Backend (ML Training & Serving) | Remote Canada | 2 days ago | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7800446003) |
+| 🚀 Affirm | Software Engineer II, Backend (ML Training & Serving) | Remote US | 2 days ago | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7800444003) |
+| 🚀 Affirm | Software Engineer II, Backend (Furnishing Platform) | Remote Poland | 2 days ago | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7799348003) |
+| 🚀 Affirm | Software Engineer II , Backend, (Furnishing Platform) | Remote Spain | 2 days ago | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7799346003) |
+| 🔥 NVIDIA | Backend Compiler Engineer - New College Grad 2026 | Santa Clara, CA, US | 2 days ago | [Apply](https://www.indeed.com/viewjob?jk=ce865a2b9ec813b7) |
+| 🔥 NVIDIA | Backend Compiler Engineer - New College Grad 2026 | US, CA, Santa Clara | 2 days ago | [Apply](https://nvidia.wd5.myworkdayjobs.com/job/US-CA-Santa-Clara/Backend-Compiler-Engineer---New-College-Grad-2026_JR2021242) |
+| 🚀 Affirm | Software Engineer II, Backend (Test Infra) | Remote Canada | 5 days ago | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7727322003) |
+| 🚀 Affirm | Software Engineer II, Backend (Test Infra) | Remote US | 5 days ago | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7727320003) |
+| 🚀 Robinhood | Software Engineer, Backend | Menlo Park, CA | 5 days ago | [Apply](https://boards.greenhouse.io/robinhood/jobs/7263592?t=gh_src=&gh_jid=7263592) |
+| 🚀 Vercel | Software Engineer, Backend | Remote - United States | 2026-07-07 | [Apply](https://job-boards.greenhouse.io/vercel/jobs/5430088004) |
+| AppLovin | Backend Engineer II | Palo Alto, CA | 2026-07-06 | [Apply](https://boards.greenhouse.io/applovin/jobs/4375888006?gh_jid=4375888006) |
+| AppLovin | Backend Engineer, New Grad | Palo Alto, CA | 2026-07-06 | [Apply](https://boards.greenhouse.io/applovin/jobs/4451556006?gh_jid=4451556006) |
+| 🚀 Affirm | Software Engineer II, Backend (Reliability Platform) | Remote Canada | 2026-06-26 | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7764836003) |
+| 🚀 Affirm | Software Engineer II, Backend (Reliability Platform) | Remote US | 2026-06-26 | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7764834003) |
+| 🚀 Brex | Software Engineer II, Backend | Vancouver, British Columbia, Canada | 2026-06-26 | [Apply](https://www.brex.com/careers/8603327002?gh_jid=8603327002) |
+| 🚀 Affirm | Software Engineer II, Back-end (Card Mgmt & Transaction Processing) | Remote Canada | 2026-06-24 | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7777094003) |
+| 🚀 Affirm | Software Engineer II, Back-end (Card Mgmt & Transaction Processing) | Remote US | 2026-06-24 | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7766277003) |
+| 🚀 Airtable | Software Engineer, Product Backend (8+ YOE) | San Francisco, CA; New York, NY | 2026-06-23 | [Apply](https://job-boards.greenhouse.io/airtable/jobs/8397618002) |
+| 🚀 Affirm | Software Engineer II, Backend (Capital Orchestration) | Remote US | 2026-06-18 | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7749755003) |
+| 🚀 Affirm | Software Engineer II, Backend (PMI Integrations) | Remote Canada | 2026-06-18 | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7590373003) |
+| 🚀 Waymo | Software Engineer Backend - Simulation | Mountain View | 2026-06-16 | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7307289) |
+| 🚀 Brex | Software Engineer II, Backend | New York, New York, United States | 2026-06-12 | [Apply](https://www.brex.com/careers/8536424002?gh_jid=8536424002) |
+| 🚀 Pinterest | Software Engineer II, Backend | San Francisco, CA, US; Seattle, WA, US | 2026-06-12 | [Apply](https://www.pinterestcareers.com/jobs/?gh_jid=4813946) |
+| Cockroach Labs | Software Engineer (Backend), GTM Tooling | New York, NY | 2026-06-10 | [Apply](https://www.cockroachlabs.com/careers/job/?gh_jid=7874104) |
+| 🚀 Brex | Software Engineer II, Backend | San Francisco, California, United States | 2026-06-10 | [Apply](https://www.brex.com/careers/8459783002?gh_jid=8459783002) |
+| 🚀 Pinterest | Software Engineer I, Backend | Seattle, WA, US; San Francisco, CA, US | 2026-06-09 | [Apply](https://www.pinterestcareers.com/jobs/?gh_jid=6816337) |
+| 🚀 Pinterest | Software Engineer II, Backend, tvScientific | San Francisco, CA, US; Remote, US | 2026-06-04 | [Apply](https://www.pinterestcareers.com/jobs/?gh_jid=7782552) |
+| 🚀 Pinterest | Software Engineer II, Backend | Toronto, ON, CA | 2026-06-04 | [Apply](https://www.pinterestcareers.com/jobs/?gh_jid=5132899) |
+| 🚀 Glean | Software Engineer, Backend | Bangalore, India | 2026-05-27 | [Apply](https://job-boards.greenhouse.io/gleanwork/jobs/4006731005) |
+
+## 📲 Mobile Engineering New Grad Roles
+
+[Back to top](#-2026-new-grad-positions)
+
+| Company | Role | Location | Posted | Apply |
+|---------|------|----------|--------|-------|
+| Anduril Industries | Software Engineer - Mobile, Android | Costa Mesa, California, United States | Today | [Apply](https://boards.greenhouse.io/andurilindustries/jobs/5163532007?gh_jid=5163532007) |
+| Booz Allen Hamilton | Android CNO Software Developer | Annapolis Junction, MD | 1 day ago | [Apply](https://bah.wd1.myworkdayjobs.com/job/Annapolis-Junction-MD/Android-CNO-Software-Developer_R0237796) |
+| 🚀 Duolingo | Software Engineer II, Android | Pittsburgh, PA | 5 days ago | [Apply](https://careers.duolingo.com/jobs/8628658002?gh_jid=8628658002) |
+| 🚀 Duolingo | Software Engineer II, Android | New York, NY | 5 days ago | [Apply](https://careers.duolingo.com/jobs/8628670002?gh_jid=8628670002) |
+| 🚀 Chime | Mobile Software Engineer, Lending | San Francisco, CA, USA | 5 days ago | [Apply](https://boards.greenhouse.io/chime/jobs/8535338002?gh_jid=8535338002) |
+| Rocket | iOS Mobile Software Developer I | Seattle, WA, US | 2026-07-08 | [Apply](https://www.indeed.com/viewjob?jk=15a2c2864759e26a) |
+| 🔥 Airbnb | Android Software Engineer, Quality Platform | Remote, Brazil | 2026-06-25 | [Apply](https://careers.airbnb.com/positions/7744247?gh_jid=7744247) |
+| StockX | Software Engineer-iOS | Bangalore, India | 2026-06-24 | [Apply](https://job-boards.greenhouse.io/stockx/jobs/8601983002) |
+| StockX | Software Engineer - iOS | Bangalore, India | 2026-06-24 | [Apply](https://job-boards.greenhouse.io/stockx/jobs/8603916002) |
+| 🚀 Pinterest | Software Engineer, iOS | Toronto, ON, CA | 2026-06-15 | [Apply](https://www.pinterestcareers.com/jobs/?gh_jid=6922682) |
+| 🚀 Pinterest | Software Engineer II, Android | Toronto, ON, CA | 2026-06-10 | [Apply](https://www.pinterestcareers.com/jobs/?gh_jid=7987854) |
+
+## 🔒 Security Engineering New Grad Roles
+
+[Back to top](#-2026-new-grad-positions)
+
+| Company | Role | Location | Posted | Apply |
+|---------|------|----------|--------|-------|
+| xAI | Application Security Engineer | Palo Alto, CA | Today | [Apply](https://job-boards.greenhouse.io/xai/jobs/4559147007) |
+| xAI | Infrastructure Security Engineer | Austin, TX; New York, NY; Palo Alto, CA; Washington, D.C. | Today | [Apply](https://job-boards.greenhouse.io/xai/jobs/5090998007) |
+| xAI | Security Engineer - Azure Government | Palo Alto, CA; Washington, D.C. | Today | [Apply](https://job-boards.greenhouse.io/xai/jobs/5050657007) |
+| xAI | Security Engineer - Governance Risk Compliance | New York, NY; Palo Alto, CA; Washington, D.C. | Today | [Apply](https://job-boards.greenhouse.io/xai/jobs/5007261007) |
+| 🚀 SpaceX | Embedded Security Engineer (Starlink) | Bastrop, TX | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8624836002?gh_jid=8624836002) |
+| 🚀 SpaceX | Embedded Security Engineer (Starlink) | Redmond, WA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8543670002?gh_jid=8543670002) |
+| 🚀 SpaceX | Embedded Security Engineer (Starlink) | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8577410002?gh_jid=8577410002) |
+| 🚀 SpaceX | Product Security Engineer (Starlink) | Redmond, WA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8543671002?gh_jid=8543671002) |
+| 🚀 SpaceX | Product Security Engineer (Starlink) | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8577411002?gh_jid=8577411002) |
+| 🚀 SpaceX | Product Security Engineer (Starlink) | Bastrop, TX | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8624835002?gh_jid=8624835002) |
+| 🚀 SpaceX | Product Security Engineer (Starshield) | Washington, DC | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8492058002?gh_jid=8492058002) |
+| 🚀 SpaceX | Security Engineer | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8567571002?gh_jid=8567571002) |
+| 🚀 SpaceX | Security Engineer | Cape Canaveral, FL | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8567522002?gh_jid=8567522002) |
+| 🚀 SpaceX | Security Engineer (Blue Team) | Redmond, WA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8611050002?gh_jid=8611050002) |
+| 🚀 SpaceX | Security Engineer (Blue Team) | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8611223002?gh_jid=8611223002) |
+| 🚀 SpaceX | Security Engineer (Embedded & Networking) | Cape Canaveral, FL | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8593385002?gh_jid=8593385002) |
+| 🚀 SpaceX | Security Engineer (Embedded & Networking) | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8593384002?gh_jid=8593384002) |
+| 🚀 SpaceX | Security Engineer (Embedded OT) | Cape Canaveral, FL | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8593389002?gh_jid=8593389002) |
+| 🚀 SpaceX | Security Engineer (Embedded OT) | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8593388002?gh_jid=8593388002) |
+| 🚀 StubHub | Software Engineer II - Product Security | Los Angeles, California, United States | Today | [Apply](https://job-boards.eu.greenhouse.io/stubhubinc/jobs/4903899101) |
 
 ## 🤖 Data Science & ML New Grad Roles
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -61,15 +61,15 @@
   </div>
 
   <!-- Pure-JS helper for the LIVE chip, loadable in Node for unit testing. -->
-  <script src="terminal/live-stamp-format.js?v=17"></script>
+  <script src="terminal/live-stamp-format.js?v=18"></script>
 
   <!-- Cache-bust the bundle when its shape changes. Bump v= on data-shape edits. -->
-  <script type="text/babel" src="terminal/data.jsx?v=17"></script>
-  <script type="text/babel" src="terminal/contributors-data.jsx?v=17"></script>
-  <script type="text/babel" src="terminal/dashboard.jsx?v=17"></script>
-  <script type="text/babel" src="terminal/contributors.jsx?v=17"></script>
-  <script type="text/babel" src="terminal/live-stamp.jsx?v=17"></script>
-  <script type="text/babel" src="terminal/app.jsx?v=17"></script>
+  <script type="text/babel" src="terminal/data.jsx?v=18"></script>
+  <script type="text/babel" src="terminal/contributors-data.jsx?v=18"></script>
+  <script type="text/babel" src="terminal/dashboard.jsx?v=18"></script>
+  <script type="text/babel" src="terminal/contributors.jsx?v=18"></script>
+  <script type="text/babel" src="terminal/live-stamp.jsx?v=18"></script>
+  <script type="text/babel" src="terminal/app.jsx?v=18"></script>
 
   <script type="text/babel">
     (async () => {

--- a/docs/terminal/dashboard.jsx
+++ b/docs/terminal/dashboard.jsx
@@ -182,7 +182,7 @@ function DashboardDirection() {
         {/* ─ Left rail: filters as compact chip list ─ */}
         <div style={{ borderRight: `1px solid ${BBG.rule2}`, overflow: 'auto' }}>
           <ChipGroup title="ROLE">
-            {['SWE','ML','DATA','INFRA','PM','QUANT','HW','OTHER'].map(t => (
+            {['SWE','FE','BE','MOBILE','SEC','ML','DATA','INFRA','PM','QUANT','HW','OTHER'].map(t => (
               <Chip key={t} on={filters.type.has(t)} onClick={() => toggleSet('type', t)} label={TYPE_LABEL[t]} />
             ))}
           </ChipGroup>

--- a/docs/terminal/data.jsx
+++ b/docs/terminal/data.jsx
@@ -9,7 +9,7 @@
 // Canonical job categories — the single source of truth shared with
 // scripts/update_jobs.py (CATEGORY_PATTERNS), docs/jobs.json (meta.categories),
 // and the README. Keep these ids/order in step with CATEGORY_TYPE below.
-const TYPE_LABEL = { SWE:'swe', ML:'ml', DATA:'data', INFRA:'infra', PM:'product', QUANT:'quant', HW:'hardware', OTHER:'other' };
+const TYPE_LABEL = { SWE:'swe', FE:'frontend', BE:'backend', MOBILE:'mobile', SEC:'security', ML:'ml', DATA:'data', INFRA:'infra', PM:'product', QUANT:'quant', HW:'hardware', OTHER:'other' };
 const SIZE_LABEL = { S:'<50', M:'50–500', L:'500–5k', XL:'5k+' };
 const RMT_LABEL  = { remote:'remote', hybrid:'hybrid', onsite:'onsite' };
 
@@ -40,6 +40,10 @@ function deadlineHot(dl) { return daysLeft(dl) <= 14; }
 // re-deriving a separate taxonomy from job titles.
 const CATEGORY_TYPE = {
   software_engineering: 'SWE',
+  frontend:             'FE',
+  backend:              'BE',
+  mobile:               'MOBILE',
+  security:             'SEC',
   data_ml:              'ML',
   data_engineering:     'DATA',
   infrastructure_sre:   'INFRA',

--- a/scripts/update_jobs.py
+++ b/scripts/update_jobs.py
@@ -406,15 +406,54 @@ STARTUPS = {
 # Note on matching: Keywords are matched using word boundaries (exact phrase matching using regex '\b').
 # If no keyword matches naturally, the job defaults to the 'other' category block.
 CATEGORY_PATTERNS = {
+    # Specialty engineering tracks. These are matched against the job TITLE only
+    # (see TITLE_DRIVEN_CATEGORIES) so a backend role whose description merely
+    # mentions "frontend" is not misfiled, and they are ordered before the broad
+    # 'software_engineering' bucket so a titled specialist wins over the general
+    # match.
+    'security': {
+        'name': 'Security Engineering',
+        'emoji': '🔒',
+        'keywords': [
+            'security engineer', 'security analyst', 'application security',
+            'appsec', 'infosec', 'cybersecurity', 'cyber security',
+            'cloud security', 'product security', 'devsecops',
+            'penetration tester', 'security researcher'
+        ]
+    },
+    'mobile': {
+        'name': 'Mobile Engineering',
+        'emoji': '📲',
+        'keywords': [
+            'mobile engineer', 'mobile developer', 'mobile software engineer',
+            'mobile application', 'ios engineer', 'ios developer',
+            'android engineer', 'android developer', 'react native',
+            'ios', 'android'
+        ]
+    },
+    'frontend': {
+        'name': 'Frontend Engineering',
+        'emoji': '🎨',
+        'keywords': [
+            'frontend', 'front-end', 'front end', 'ui engineer',
+            'ui developer', 'web developer'
+        ]
+    },
+    'backend': {
+        'name': 'Backend Engineering',
+        'emoji': '⚙️',
+        'keywords': [
+            'backend', 'back-end', 'back end', 'server-side', 'server side',
+            'api engineer'
+        ]
+    },
     'software_engineering': {
         'name': 'Software Engineering',
         'emoji': '💻',
         'keywords': [
             'software engineer', 'software developer', 'swe', 'full stack',
-            'fullstack', 'frontend', 'front-end', 'backend', 'back-end',
-            'web developer', 'mobile developer', 'ios developer', 'android developer',
-            'application developer', 'systems engineer', 'platform engineer',
-            'solutions engineer', 'integration engineer', 'api engineer',
+            'fullstack', 'application developer', 'systems engineer',
+            'platform engineer', 'solutions engineer', 'integration engineer',
             'developer advocate', 'devrel'
         ]
     },
@@ -439,11 +478,11 @@ CATEGORY_PATTERNS = {
         'name': 'Infrastructure & SRE',
         'emoji': '🏗️',
         'keywords': [
-            'sre', 'site reliability', 'devops', 'infrastructure', 'platform', 'cybersecurity', 'infosec',
+            'sre', 'site reliability', 'devops', 'infrastructure', 'platform',
             'cloud engineer', 'systems administrator', 'network engineer',
             'network automation', 'noc', 'network operations center', 'network operations',
             'network performance', 'netops', 'network ops', 'noc engineer',
-            'security engineer', 'devsecops', 'reliability engineer'
+            'reliability engineer'
         ]
     },
     'product_management': {
@@ -477,6 +516,11 @@ CATEGORY_PATTERNS = {
         'keywords': []
     }
 }
+
+# Categories matched against the job title only (not the description) to keep
+# fine-grained specialty buckets from being polluted by incidental mentions of
+# an adjacent stack in a long job description.
+TITLE_DRIVEN_CATEGORIES = frozenset({'security', 'mobile', 'frontend', 'backend'})
 
 # Sponsorship/visa keywords
 NO_SPONSORSHIP_KEYWORDS = [
@@ -657,12 +701,17 @@ def categorize_job(title: str, description: str = '') -> Dict[str, Any]:
     for category_id, category_info in CATEGORY_PATTERNS.items():
         if category_id == 'other':
             continue
+        # Specialty tracks (frontend/backend/mobile/security) match on the title
+        # only: a title is an unambiguous signal, whereas descriptions routinely
+        # mention adjacent stacks ("partner with the frontend team") and would
+        # cross-contaminate these fine-grained buckets.
+        haystack = title_lower if category_id in TITLE_DRIVEN_CATEGORIES else combined
         for keyword in category_info['keywords']:
             if category_id == 'infrastructure_sre' and keyword in NETWORK_INFRASTRUCTURE_KEYWORDS:
                 continue
             # Use word boundaries for exact phrase matching, safely escape the keyword
             pattern = r'\b' + re.escape(keyword) + r'\b'
-            if re.search(pattern, combined):
+            if re.search(pattern, haystack):
                 return {
                     'id': category_id,
                     'name': category_info['name'],

--- a/tests/test_categorize.py
+++ b/tests/test_categorize.py
@@ -38,14 +38,26 @@ class TestCategorizeJob:
 
     def test_frontend_engineer(self):
         result = categorize_job("Frontend Engineer - React")
-        assert result["id"] == "software_engineering"
+        assert result["id"] == "frontend"
+        assert result["name"] == "Frontend Engineering"
 
     def test_backend_engineer(self):
         result = categorize_job("Backend Engineer (Python)")
-        assert result["id"] == "software_engineering"
+        assert result["id"] == "backend"
 
     def test_backend_go_engineer(self):
         result = categorize_job("Backend Engineer (Go)")
+        assert result["id"] == "backend"
+
+    def test_ios_engineer_is_mobile(self):
+        result = categorize_job("iOS Engineer, New Grad")
+        assert result["id"] == "mobile"
+
+    def test_generic_swe_title_stays_software_engineering(self):
+        # A description mentioning "frontend" must NOT reclassify a general SWE
+        # role — specialty tracks are matched on the title only.
+        result = categorize_job("Software Engineer, New Grad",
+                                "You will work closely with our frontend team.")
         assert result["id"] == "software_engineering"
 
     def test_ml_engineer(self):
@@ -344,9 +356,16 @@ class TestDetectSponsorshipFlags:
 
 def test_categorize_cybersecurity_engineer():
     result = categorize_job("Cybersecurity Engineer")
-    assert result["id"] == "infrastructure_sre"
+    assert result["id"] == "security"
 
 
 def test_categorize_infosec_analyst():
     result = categorize_job("Infosec Analyst")
+    assert result["id"] == "security"
+
+
+def test_network_security_stays_infrastructure():
+    # Network-focused security remains infra (network title special-case runs
+    # before the security keyword match).
+    result = categorize_job("Network Security Engineer")
     assert result["id"] == "infrastructure_sre"

--- a/tests/test_category_taxonomy_sync.py
+++ b/tests/test_category_taxonomy_sync.py
@@ -71,10 +71,15 @@ def test_terminal_type_codes_are_consistent_across_map_labels_and_chips():
     )
 
 
-def test_no_legacy_title_derived_types_remain():
-    """The removed title-regex types must not linger as filter chips."""
+def test_specialty_categories_are_backed_by_the_scraper():
+    """Frontend/Backend/Mobile/Security are now real scraper categories, so the
+    site's specialty filter chips must be present AND backed by CATEGORY_PATTERNS
+    (i.e. not client-only title-regex types like the removed scheme)."""
+    for specialty in ("frontend", "backend", "mobile", "security"):
+        assert specialty in CANONICAL_IDS, f"{specialty} missing from CATEGORY_PATTERNS"
+
     dashboard = _read("docs", "terminal", "dashboard.jsx")
     chip_block = re.search(r"\[((?:'[A-Z]+',?\s*)+)\]\.map\(t =>", dashboard).group(1)
     chip_codes = set(re.findall(r"'([A-Z]+)'", chip_block))
-    for legacy in ("FE", "BE", "SEC", "MOBILE"):
-        assert legacy not in chip_codes, f"legacy title-derived type {legacy!r} still present"
+    for code in ("FE", "BE", "MOBILE", "SEC"):
+        assert code in chip_codes, f"specialty filter chip {code!r} missing"


### PR DESCRIPTION
## What & why

Follow-up to #339. Per the decision to **keep the granular filters and do it properly**, the specialty tracks (Frontend, Backend, Mobile, Security) are now **real scraper categories** — so they flow consistently from the scraper → `docs/jobs.json` `meta.categories` → README → website, instead of the website re-deriving a separate title-regex taxonomy.

The canonical taxonomy grows from 8 → **12 categories**.

## Changes

- **`scripts/update_jobs.py`**: added `security`, `mobile`, `frontend`, `backend` to `CATEGORY_PATTERNS`, split out of `software_engineering` (and `security` out of `infrastructure_sre`). These four are **title-driven** (`TITLE_DRIVEN_CATEGORIES`) so a backend role whose *description* mentions "frontend" isn't misfiled — mirrors the old client behavior but now authoritative.
- **`docs/jobs.json`**: re-categorized the 1458 committed jobs and rebuilt `meta.categories` so the deployed state is immediately consistent (the next scrape reproduces it). Distribution: `SWE 861 · FE 9 · BE 32 · MOBILE 11 · SEC 85 · ML 149 · DATA 25 · INFRA 122 · PM 3 · QUANT 4 · HW 14 · OTHER 143 = 1458`.
- **README**: added the 4 nav entries, sections (real sample tables), and `COUNT` markers; counts re-synced from meta and **sum to the total (1458)**.
- **`docs/terminal/`**: `data.jsx` `CATEGORY_TYPE`/`TYPE_LABEL` and the dashboard filter chips now carry all 12 canonical types (FE/BE/MOBILE/SEC are back — now backed by data). `index.html` cache-bust → `v18`.
- **tests**: updated categorization expectations, added title-vs-description and network-security regression tests, and extended `test_category_taxonomy_sync.py` to require the specialty categories across every surface.

## Verification
- Categorization validated on real data (spot-checks + full distribution); every `job.category.id` is canonical.
- README markers == `data.jsx` CATEGORY_TYPE == `jobs.json` meta == `CATEGORY_PATTERNS` (all 12).
- Full suite green (810 tests); pre-commit clean.