### PR TITLE
feat: keep README job tables live (top-10 recent per category + live-board links)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,580 +73,28 @@
 
 ---
 
+<!-- CATEGORY-LISTINGS:START - auto-generated from docs/jobs.json by scripts/sync_readme_jobs.py; do not edit by hand -->
+
+> 📋 **Live listings** — the 10 most recently posted roles per category, refreshed every 5 minutes. Browse and filter all **1,465** live roles on the **[live job board](https://jobs.riteshrana.engineer/)**.
+
 ## 💻 Software Engineering New Grad Roles
 
 [Back to top](#-2026-new-grad-positions)
 
 | Company | Role | Location | Posted | Apply |
 |---------|------|----------|--------|-------|
-| 🚀 Waymo | Onboard Developer Platform Software Engineer | Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7461052) |
-| 🚀 Waymo | Onboard Frameworks Software Engineer | Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7412386) |
-| 🚀 Waymo | Onboard Infrastructure Software Engineer | Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7461103) |
-| 🚀 Waymo | Post-Silicon Validation Software Engineer | Bangalore, Karnataka, India | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7590331) |
-| 🚀 Waymo | Software Engineer, Applied Machine Learning, Planner Technology | Mountain View, California | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7163224) |
-| 🚀 Waymo | Software Engineer Backend - Simulation | Mountain View | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7307289) |
-| 🚀 Waymo | Software Engineer, Bulk/Interactive Inference | Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7466529) |
-| 🚀 Waymo | Software Engineer, Calibration Systems | Mountain View, California, United States; San Francisco, California, United States | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7456229) |
-| 🚀 Waymo | Software Engineer, Commercialization Onboard Platform | Mountain View, CA, USA ;  San Francisco, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7426815) |
-| 🚀 Waymo | Software Engineer, Data & Evaluation | Mountain View, CA, USA ; San Francisco, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7428871) |
-| 🚀 Waymo | Software Engineer, Embedded Systems / Robotics  | Mountain View, CA, US | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7429873) |
-| 🚀 Waymo | Software Engineer, Event Response | San Francisco, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7430650) |
-| 🚀 Waymo | Software Engineer, Fleet Orchestration & Optimization | Mountain View, CA, USA; San Francisco, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7430364) |
-| 🚀 Waymo | Software Engineer, Fleet Response | Mountain View, CA, USA ; San Francisco, CA, USA  | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7473934) |
-| 🚀 Waymo | Software Engineer, Fleet Response (Full Stack) | Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7429906) |
-| 🚀 Waymo | Software Engineer, GPU | Mountain View, CA, USA; New York, NY, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7554830) |
-| 🚀 Waymo | Software Engineer, Labeling Infrastructure | Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7416895) |
-| 🚀 Waymo | Software Engineer, Large Model Evaluation | Mountain View, California, USA; San Francisco, California, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7487849) |
-| 🚀 Waymo | Software Engineer, Logs Infrastructure | Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7389370) |
-| 🚀 Waymo | Software Engineer, Marketplace Optimization - ML Infra | Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7436243) |
-| 🚀 Waymo | Software Engineer, ML Efficiency | Mountain View, CA, USA; New York, CA, USA; Seattle, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7443590) |
-| 🚀 Waymo | Software Engineer, ML Inference, Simulation Infrastructure | Mountain View, CA, USA; San Francisco, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7353876) |
-| 🚀 Waymo | Software Engineer, ML Tools | Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7426718) |
-| 🚀 Waymo | Software Engineer, Model Lifecycle | Kirkland, Washington, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7609435) |
-| 🚀 Waymo | Software Engineer, Multiverse | San Francisco, CA, USA; Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7531397) |
-| 🚀 Waymo | Software Engineer, Onboard Reliability Infra | Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7461072) |
-| 🚀 Waymo | Software Engineer, Perception Evaluation | Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7256244) |
-| 🚀 Waymo | Software Engineer, Perception Evaluation and Test Automation | Mountain View, CA, USA; San Francisco, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7449712) |
-| 🚀 Waymo | Software Engineer, Perception Optimization | Mountain View, California, United States; San Francisco, California, United States | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7450565) |
-| 🚀 Waymo | Software Engineer, Planner | Mountain View, CA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7459622) |
-| 🚀 Waymo | Software Engineer, Planner Reasoning | Mountain View, CA, USA; San Francisco, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7259110) |
-| 🚀 Waymo | Software Engineer, Planner Reasoning, ML Infrastructure | Mountain View, California, United States; San Francisco, California, United States | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7483979) |
-| 🚀 Waymo | Software Engineer, Planner Vehicle Dynamics | Mountain View, California | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7141380) |
-| 🚀 Waymo | Software Engineer, Privacy | Mountain View, CA, USA  | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7547529) |
-| 🚀 Waymo | Software Engineer, Quantitative Evaluations | Mountain View, CA, USA; San Francisco, CA, USA  | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7466534) |
-| 🚀 Waymo | Software Engineer, Sensor/Imaging | Mountain View, CA, US; San Francisco, CA, US | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7587455) |
-| 🚀 Waymo | Software Engineer, Simulation Infrastructure | Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7430555) |
-| 🚀 Waymo | Software Engineer, Simulator Evaluation | Mountain View, California, United States; San Francisco, California, United States | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=6562547) |
-| 🚀 Waymo | Software Engineer, Statistical Evaluation and Sampling | Mountain View, CA, USA; San Francisco, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7543520) |
-| 🚀 Waymo | Software Engineer, Test Automation Infrastructure | San Francisco, CA, US; Mountain View, CA, US | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7532414) |
-| 🚀 Waymo | Software Engineer, Trip Platform | Mountain View, CA, US | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7433503) |
-| 🚀 Waymo | Systems Engineer, Behavioral Requirements | Mountain View, CA, US; San Francisco, CA,US | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7545185) |
-| 🚀 Waymo | Systems Engineer, Conflict Behavior | Mountain View, CA, USA ; San Francisco, CA USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7490337) |
-| 🚀 Waymo | Systems Engineer, Motion Control  | Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7586057) |
-| 🚀 Waymo | Systems Engineer, Networks | Mountain View, CA, US | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7510381) |
-| 🚀 Waymo | Systems Engineer, Perception | Mountain View, CA, US; San Francisco, CA, US | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7367785) |
-| 🚀 Waymo | Systems Engineer, Power Systems (Low Voltage) | Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7572411) |
-| 🚀 Waymo | Systems Engineer, Sensing  | Mountain View, CA, US;San Francisco, CA, US | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=6511655) |
-| 🚀 SpaceX | Software Engineer, Embedded Software (Starshield) | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8436708002?gh_jid=8436708002) |
-| 🚀 SpaceX | Software Engineer, Starlink Network | Sunnyvale, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8458001002?gh_jid=8458001002) |
-| 🚀 SpaceX | Software Engineer, C++ (Starlink) | Sunnyvale, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8451960002?gh_jid=8451960002) |
-| Riot Games | Software Engineer II, Community Tech - Publishing Platform | Los Angeles, USA | Today | [Apply](https://www.riotgames.com/en/work-with-us/job/7195851?gh_jid=7195851) |
-| Amplitude | Full Stack Engineer II (Activation) | Vancouver, BC, Canada | Today | [Apply](https://job-boards.greenhouse.io/amplitude/jobs/8359322002) |
-| Amplitude | Software Engineer II, AI Security | San Francisco, CA | Today | [Apply](https://job-boards.greenhouse.io/amplitude/jobs/8393339002) |
-| Amplitude | Software Engineer II, Backend/Data Systems | San Francisco, CA | Today | [Apply](https://job-boards.greenhouse.io/amplitude/jobs/8316249002) |
-| Abnormal Security | Software Engineer 2 - Dev Accelerator | Remote - USA | Today | [Apply](https://abnormal.ai/careers/jobs/7640818003?gh_jid=7640818003) |
-| 🚀 SpaceX | IT Systems Engineer - Top Secret Clearance 🇺🇸 | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8245295002?gh_jid=8245295002) |
-| 🚀 Affirm | Software Engineer II, Backend (Affirm Card) | Remote Canada | Today | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7615054003) |
-| 🚀 Affirm | Software Engineer II, Backend (Fraud) | Remote Canada | Today | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7624379003) |
-| 🚀 Affirm | Software Engineer II, Full-Stack (Card Acquisition) | Remote Canada | Today | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7618869003) |
-| 🚀 Scale AI | ML Systems Engineer, Robotics | San Francisco, CA | Today | [Apply](https://job-boards.greenhouse.io/scaleai/jobs/4663053005) |
-| 🚀 Scale AI | Software Engineer, Robotics & Autonomous Systems | San Francisco, CA | Today | [Apply](https://job-boards.greenhouse.io/scaleai/jobs/4618065005) |
-| 🚀 Scale AI | Software Engineer, Full Stack – Scale GP | San Francisco, CA; New York, NY | Today | [Apply](https://job-boards.greenhouse.io/scaleai/jobs/4637485005) |
-| 🚀 Scale AI | Software Engineer, Gen AI | San Francisco, CA; New York, NY | Today | [Apply](https://job-boards.greenhouse.io/scaleai/jobs/4591300005) |
-| 🚀 Scale AI | Software Engineer, Platform | San Francisco, CA; New York, NY | Today | [Apply](https://job-boards.greenhouse.io/scaleai/jobs/4594879005) |
-| 🚀 Scale AI | Infrastructure Software Engineer, Enterprise GenAI | San Francisco, CA; New York, NY | Today | [Apply](https://job-boards.greenhouse.io/scaleai/jobs/4665557005) |
-| 🚀 Scale AI | Mission Software Engineer, Public Sector | Boston, Massachusetts ; Honolulu, HI; San Diego, CA; San Francisco, CA; St. Louis, MO; New York, NY; Washington, DC | Today | [Apply](https://job-boards.greenhouse.io/scaleai/jobs/4481921005) |
-| 🚀 Scale AI | Software Engineer, Enterprise AI | New York, NY; San Francisco, CA | Today | [Apply](https://job-boards.greenhouse.io/scaleai/jobs/4513943005) |
-| 🚀 Scale AI | Software Engineer, Infrastructure & Security | San Francisco, CA; St. Louis, MO; New York, NY; Washington, DC | Today | [Apply](https://job-boards.greenhouse.io/scaleai/jobs/4363623005) |
-| Tanium | Software Engineer II | Durham, NC (Hybrid) | Today | [Apply](https://job-boards.greenhouse.io/tanium/jobs/7669951) |
-| Tanium | Software Engineer II - Full Stack  | Addison, TX (Hybrid); Durham, NC (Hybrid) | Today | [Apply](https://job-boards.greenhouse.io/tanium/jobs/7696581) |
-| 🚀 Chime | Software Engineer, Financial Platform | San Francisco, CA, USA | Today | [Apply](https://boards.greenhouse.io/chime/jobs/8183064002?gh_jid=8183064002) |
-| 🚀 SpaceX | Security Software Engineer (Starlink) | Redmond, WA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8406031002?gh_jid=8406031002) |
-| 🚀 SpaceX | Security Software Engineer (Starlink) | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8445643002?gh_jid=8445643002) |
-| 🚀 SpaceX | Software Engineer, DevOps (Starlink) | Redmond, WA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8443737002?gh_jid=8443737002) |
-| 🚀 SpaceX | Security Software Engineer (Starlink) | Bastrop, TX | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8324498002?gh_jid=8324498002) |
-| Abnormal Security | Software Engineer 2 - Insider Risk | Remote - Canada | Today | [Apply](https://abnormal.ai/careers/jobs/7637315003?gh_jid=7637315003) |
-| Abnormal Security | Software Engineer 2 - Insider Risk | Remote - USA | Today | [Apply](https://abnormal.ai/careers/jobs/7636366003?gh_jid=7636366003) |
-| 🚀 Discord | Full-Stack Software Engineer, Ads | San Francisco Bay Area | Today | [Apply](https://job-boards.greenhouse.io/discord/jobs/8362007002) |
-| 🚀 Grammarly | Software Engineer, Backend (Superhuman Mail) | San Francisco, CA; United States; Canada; Argentina; Mexico; Brazil | Today | [Apply](https://job-boards.greenhouse.io/grammarly/jobs/7339557) |
-| 🚀 Okta | Software Engineer II - Passwordless  | San Francisco, California | Today | [Apply](https://www.okta.com/company/careers/opportunity/7696955?gh_jid=7696955) |
-| 🚀 SpaceX | Software Engineer, PCBA (Starlink) | Redmond, WA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8456289002?gh_jid=8456289002) |
-| Dialpad | Software Engineer, Fullstack (Support Core) | Vancouver, Canada | Today | [Apply](https://job-boards.greenhouse.io/dialpad/jobs/8407060002) |
-| Dialpad | Software Engineer, Fullstack (Sell Core) | Vancouver, Canada | Today | [Apply](https://job-boards.greenhouse.io/dialpad/jobs/8407054002) |
-| Dialpad | Software Engineer, Support Core | San Ramon, US | Today | [Apply](https://job-boards.greenhouse.io/dialpad/jobs/8407044002) |
-| Dialpad | Software Engineer (Integrations) | Bengaluru, India | Today | [Apply](https://job-boards.greenhouse.io/dialpad/jobs/8400250002) |
-| Scopely | Software Engineer | US - Culver City, United States | Today | [Apply](https://job-boards.greenhouse.io/scopely/jobs/5066028008) |
-| 🚀 Twilio | Software Engineer (L3) | Remote - India | Today | [Apply](https://job-boards.greenhouse.io/twilio/jobs/7359642) |
-| 🚀 Twilio | Cloud Software Engineer | Remote - Ireland | Today | [Apply](https://job-boards.greenhouse.io/twilio/jobs/7484699) |
-| 🚀 Twilio | Software Engineer | Remote - Ireland | Today | [Apply](https://job-boards.greenhouse.io/twilio/jobs/7661922) |
-| 🚀 MongoDB | Software Engineer 3 (SE3), Developer Productivity (Backstage) | United States | Today | [Apply](https://www.mongodb.com/careers/job/?gh_jid=7527309) |
-| 🚀 MongoDB | Software Engineer 3 (SE3), Developer Productivity (Backstage) | Alberta; British Columbia; Manitoba; Nova Scotia; Ontario; Quebec | Today | [Apply](https://www.mongodb.com/careers/job/?gh_jid=7527311) |
-| 🚀 Twitch | Software Engineer, Creator Sponsorships | San Francisco, CA | 1 day ago | [Apply](https://job-boards.greenhouse.io/twitch/jobs/8345959002) |
-| Riot Games | Software Engineer, Riot Client - Publishing Platform | Los Angeles, USA; Mercer Island, USA | 1 day ago | [Apply](https://www.riotgames.com/en/work-with-us/job/7545645?gh_jid=7545645) |
-| 🚀 SpaceX | Software Engineer, Starlink Growth | Redmond, WA | 1 day ago | [Apply](https://boards.greenhouse.io/spacex/jobs/8403855002?gh_jid=8403855002) |
-| 🚀 Robinhood | Software Engineer, Backend | Menlo Park, CA; New York, NY | 1 day ago | [Apply](https://boards.greenhouse.io/robinhood/jobs/7263592?t=gh_src=&gh_jid=7263592) |
-| 🚀 Robinhood | Software Engineer, Streaming Platform | Bellevue, WA | 1 day ago | [Apply](https://boards.greenhouse.io/robinhood/jobs/7542945?t=gh_src=&gh_jid=7542945) |
-| 🚀 Robinhood | Software Developer, Data Engineering | Toronto, Canada | 1 day ago | [Apply](https://boards.greenhouse.io/robinhood/jobs/7454438?t=gh_src=&gh_jid=7454438) |
-| Flexport | Software Engineer I, Finance | San Francisco, California, United States | 1 day ago | [Apply](https://boards.greenhouse.io/flexport/jobs/7354795?gh_jid=7354795) |
-| Flexport | Software Engineer I (Generalist) | Bellevue, Washington, United States | 1 day ago | [Apply](https://boards.greenhouse.io/flexport/jobs/7580661?gh_jid=7580661) |
-| Flexport | Software Engineer II (Commerce) | Bellevue, Washington, United States | 1 day ago | [Apply](https://boards.greenhouse.io/flexport/jobs/7594670?gh_jid=7594670) |
-| Flexport | Software Engineer II (Generalist) | Bellevue, Washington, United States | 1 day ago | [Apply](https://boards.greenhouse.io/flexport/jobs/7555689?gh_jid=7555689) |
-| Abnormal Security | Software Engineer II (Full Stack), Messaging Security Products | Remote - USA | 1 day ago | [Apply](https://abnormal.ai/careers/jobs/6671235003?gh_jid=6671235003) |
-| 🚀 Nuro | Software Engineer, Autonomy Visualization | Mountain View, California (HQ) | 1 day ago | [Apply](https://nuro.ai/careersitem?gh_jid=7701347) |
-| 🚀 Roblox | Software Engineer, Assessments | San Mateo, CA, United States | 1 day ago | [Apply](https://careers.roblox.com/jobs/7664878?gh_jid=7664878) |
-| 🚀 MongoDB | Software Engineer 2, AMP | Gurugram | 1 day ago | [Apply](https://www.mongodb.com/careers/job/?gh_jid=7523893) |
-| 🚀 Okta | Software Engineer in Test II | Toronto, Ontario, Canada | 1 day ago | [Apply](https://www.okta.com/company/careers/opportunity/7369387?gh_jid=7369387) |
-| 🚀 SpaceX | Quality Systems Engineer (Starlink Product) | Bastrop, TX | 1 day ago | [Apply](https://boards.greenhouse.io/spacex/jobs/8369157002?gh_jid=8369157002) |
-| Algolia | Software Engineer, Assist | Remote - France | 1 day ago | [Apply](https://job-boards.greenhouse.io/algolia/jobs/5803235004) |
-| 🚀 Unity Technologies | Software Engineer, QA | Remote, Washington, USA | 1 day ago | [Apply](https://unity.com/careers/positions/7615452?gh_jid=7615452) |
-| StockX | Software Engineer - Web | Bangalore, India | 1 day ago | [Apply](https://job-boards.greenhouse.io/stockx/jobs/8435862002) |
-| 🚀 Affirm | Software Engineer II, Backend (PMI Integrations) | Remote Canada | 1 day ago | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7590373003) |
-| 🚀 Affirm | Software Engineer II, Backend (AI Agents) | Remote Canada | 1 day ago | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7629069003) |
-| 🚀 Cloudflare | Software Engineer- AI | In-Office | 2 days ago | [Apply](https://boards.greenhouse.io/cloudflare/jobs/7603196?gh_jid=7603196) |
-| 🚀 Cloudflare | Hardware Systems Engineer | In-Office | 2 days ago | [Apply](https://boards.greenhouse.io/cloudflare/jobs/7082275?gh_jid=7082275) |
-| 🚀 Okta | Software Engineer in Test II | Bengaluru, India | 2 days ago | [Apply](https://www.okta.com/company/careers/opportunity/7124902?gh_jid=7124902) |
-| 🚀 MongoDB | Software Engineer 3 | New York City | 2 days ago | [Apply](https://www.mongodb.com/careers/job/?gh_jid=7644278) |
-| 🚀 Affirm | Software Engineer II, Backend (Credit Decisioning)  | Remote Canada | 2 days ago | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7597922003) |
-| 🚀 Affirm | Software Engineer II, Backend (Identity Decisioning)    | Remote Canada | 2 days ago | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7543980003) |
-| 🚀 SpaceX | Software Engineer, Data (Starlink) | Hawthorne, CA | 2 days ago | [Apply](https://boards.greenhouse.io/spacex/jobs/8451998002?gh_jid=8451998002) |
-| 🚀 Twilio | Software Engineer (L3) | Remote - US | 2 days ago | [Apply](https://job-boards.greenhouse.io/twilio/jobs/7472456) |
-| 🚀 MongoDB | Software Engineer 2 | Gurugram | 2 days ago | [Apply](https://www.mongodb.com/careers/job/?gh_jid=7588634) |
-| 🚀 MongoDB | Software Engineer 3 | Palo Alto; Seattle | 2 days ago | [Apply](https://www.mongodb.com/careers/job/?gh_jid=7523911) |
-| 🚀 MongoDB | Software Engineer 3 | Gurugram | 2 days ago | [Apply](https://www.mongodb.com/careers/job/?gh_jid=7597723) |
-| 🚀 MongoDB | Software Engineer 3 | Toronto | 2 days ago | [Apply](https://www.mongodb.com/careers/job/?gh_jid=7586412) |
-| 🚀 MongoDB | Software Engineer 3, AMP | Gurugram | 2 days ago | [Apply](https://www.mongodb.com/careers/job/?gh_jid=7593785) |
-| 🚀 MongoDB |  Software Engineer 3, Atlas Data Federation Customer Experience | New York City | 2 days ago | [Apply](https://www.mongodb.com/careers/job/?gh_jid=7551186) |
-| 🚀 MongoDB | Software Engineer 3, Atlas Search Systems | Toronto | 2 days ago | [Apply](https://www.mongodb.com/careers/job/?gh_jid=7662950) |
-| 🚀 MongoDB | Software Engineer 3, Enterprise Advanced  | Gurugram | 2 days ago | [Apply](https://www.mongodb.com/careers/job/?gh_jid=7585487) |
-| 🚀 MongoDB | Software Engineer 3, Insights and Telemetry | New York City | 2 days ago | [Apply](https://www.mongodb.com/careers/job/?gh_jid=7571347) |
-| 🚀 MongoDB | Software Engineer, Data Migration & Code Generation | British Columbia; Calgary | 2 days ago | [Apply](https://www.mongodb.com/careers/job/?gh_jid=7311708) |
-| 🚀 MongoDB | Software Engineer, Data Migration & Code Generation | California; Colorado; Montana; Nevada; New Mexico; Oregon; Utah; Washington | 2 days ago | [Apply](https://www.mongodb.com/careers/job/?gh_jid=7311666) |
-| 🚀 MongoDB | Software Engineer, Networking & Observability | Alberta; British Columbia; Manitoba; Nova Scotia; Ontario; Quebec | 2 days ago | [Apply](https://www.mongodb.com/careers/job/?gh_jid=7672662) |
-| 🚀 MongoDB | Software Engineer, Networking & Observability | New York City; United States | 2 days ago | [Apply](https://www.mongodb.com/careers/job/?gh_jid=7672660) |
-| Algolia | Software Engineer, Full Stack | New York, New York | 2 days ago | [Apply](https://job-boards.greenhouse.io/algolia/jobs/5806220004) |
-| 🚀 SpaceX | Software Engineer, Simulation | Hawthorne, CA | 2 days ago | [Apply](https://boards.greenhouse.io/spacex/jobs/8443290002?gh_jid=8443290002) |
-| 🚀 Instacart | Software Engineer II-  Frontend, Core Experience  | Canada - Remote (ON, AB, BC, or NS Only) | 2 days ago | [Apply](https://instacart.careers/job/?gh_jid=6907655) |
-| Mixpanel | Software Engineer, Fullstack | San Francisco  | 2 days ago | [Apply](https://job-boards.greenhouse.io/mixpanel/jobs/7670800) |
-| 🚀 Samsara | Software Engineer II, AI Platform | Remote - CA | 2 days ago | [Apply](https://www.samsara.com/company/careers/roles/7619925?gh_jid=7619925) |
-| 🚀 Samsara | Software Engineer II, Fleet Safety | Remote - US | 2 days ago | [Apply](https://www.samsara.com/company/careers/roles/7276275?gh_jid=7276275) |
-| 🚀 Samsara | Software Engineer II - Mobile Platform | San Francisco - SF9 | 2 days ago | [Apply](https://www.samsara.com/company/careers/roles/7312588?gh_jid=7312588) |
-| 🚀 Samsara | Software Engineer - Training | Remote - SF Bay Area | 2 days ago | [Apply](https://www.samsara.com/company/careers/roles/7306930?gh_jid=7306930) |
-| Sumo Logic | Software Engineer II | Bengaluru, Karnataka, India | 2 days ago | [Apply](https://job-boards.greenhouse.io/sumologic/jobs/7694504) |
-| Sumo Logic | Software Engineer II | Noida, Uttar Pradesh, India  | 2 days ago | [Apply](https://job-boards.greenhouse.io/sumologic/jobs/7685244) |
-| 🚀 Upstart | Software Engineer, Lifecycle | United States \| Remote | 5 days ago | [Apply](https://careers.upstart.com/jobs?gh_jid=7650830) |
-| 🚀 Coinbase | Software Engineer, Developer (Wallets and Onchain Tools)  | Remote - Canada | 5 days ago | [Apply](https://www.coinbase.com/careers/positions/7673310?gh_jid=7673310) |
-| 🔥 Stripe | Software Engineer, Bridge | San Francisco, NY, Seattle | 5 days ago | [Apply](https://stripe.com/jobs/search?gh_jid=7277110) |
-| 🔥 Stripe | Software Engineer, Core Technology | Bangalore | 5 days ago | [Apply](https://stripe.com/jobs/search?gh_jid=7618977) |
-| 🔥 Stripe | Software Engineer, Data & AI | Bengaluru | 5 days ago | [Apply](https://stripe.com/jobs/search?gh_jid=7529428) |
-| 🔥 Stripe | Software Engineer, Machine Learning Infrastructure | Toronto, Canada | 5 days ago | [Apply](https://stripe.com/jobs/search?gh_jid=6099228) |
-| 🔥 Stripe | Software Engineer, Machine Learning Infrastructure | Seattle, SF | 5 days ago | [Apply](https://stripe.com/jobs/search?gh_jid=7528260) |
-| 🔥 Stripe | Software Engineer, Product Security Data Platforms | Seattle | 5 days ago | [Apply](https://stripe.com/jobs/search?gh_jid=7545459) |
-| 🔥 Stripe | Software Engineer,Service Ecosystem Sustainability  | Bengaluru | 5 days ago | [Apply](https://stripe.com/jobs/search?gh_jid=6967304) |
-| 🔥 Stripe | Software Engineer - Smart Contract, Bridge | San Francisco or New York | 5 days ago | [Apply](https://stripe.com/jobs/search?gh_jid=7507904) |
-| 🚀 Nuro | Software Engineer, Software Update Infrastructure | Mountain View, California (HQ) | 5 days ago | [Apply](https://nuro.ai/careersitem?gh_jid=7235419) |
-| 🚀 SpaceX | RF Software Engineer (Starshield) | Hawthorne, CA | 5 days ago | [Apply](https://boards.greenhouse.io/spacex/jobs/8398723002?gh_jid=8398723002) |
-| 🚀 Twitch | Software Engineer I, Twitch Chat | San Francisco, CA | 5 days ago | [Apply](https://job-boards.greenhouse.io/twitch/jobs/8447271002) |
-| 🚀 Grammarly |  Software Engineer, Full-Stack | NA; Remote | 5 days ago | [Apply](https://job-boards.greenhouse.io/grammarly/jobs/7308798) |
-| 🚀 SpaceX | Full Stack Software Engineer (Starlink) | Sunnyvale, CA | 5 days ago | [Apply](https://boards.greenhouse.io/spacex/jobs/8444944002?gh_jid=8444944002) |
-| Opendoor | Software Engineer - Frontend  | Office - Washington-Seattle | 5 days ago | [Apply](https://www.opendoor.com/careers/open-positions?gh_jid=4643068006) |
-| 🚀 SpaceX | Embedded Software Engineer (Starlink) | Hawthorne, CA | 5 days ago | [Apply](https://boards.greenhouse.io/spacex/jobs/8379277002?gh_jid=8379277002) |
-| 🚀 SoFi | Software Engineer | UT - Cottonwood Heights ; UT - Remote | 5 days ago | [Apply](https://sofi.com/careers/job/7655735003?gh_jid=7655735003) |
-| 🚀 SpaceX | Security Software Engineer, Applied Computing (Starshield) | Hawthorne, CA | 5 days ago | [Apply](https://boards.greenhouse.io/spacex/jobs/8440980002?gh_jid=8440980002) |
-| 🔥 Lyft | Software Engineer, Rider | New York, NY | 5 days ago | [Apply](https://app.careerpuck.com/job-board/lyft/job/8452280002?gh_jid=8452280002) |
-| 🚀 Twilio | Software Engineer (L2) | Remote - US | 5 days ago | [Apply](https://job-boards.greenhouse.io/twilio/jobs/7671815) |
-| Grafana Labs |  Software Engineer - Platform InfraSec \| USA \| Remote   | United States (Remote) | 5 days ago | [Apply](https://job-boards.greenhouse.io/grafanalabs/jobs/5819644004) |
-| Grafana Labs |  Software Engineer - Platform InfraSec \| Canada \| Remote   | Canada (Remote) | 5 days ago | [Apply](https://job-boards.greenhouse.io/grafanalabs/jobs/5819646004) |
-| 🚀 Coinbase | Software Engineer - Salesforce Platform (EAA) | Remote - USA | 6 days ago | [Apply](https://www.coinbase.com/careers/positions/7652048?gh_jid=7652048) |
-| 🚀 Coinbase | Software Engineer, DevSec | Remote - USA | 6 days ago | [Apply](https://www.coinbase.com/careers/positions/7595352?gh_jid=7595352) |
-| 🚀 Coinbase | Software Engineer, Backend (Consumer - Advanced Trading) | Remote - USA | 6 days ago | [Apply](https://www.coinbase.com/careers/positions/7591861?gh_jid=7591861) |
-| 🚀 Coinbase | Software Engineer, EAA Integrations | Remote - India | 6 days ago | [Apply](https://www.coinbase.com/careers/positions/7558051?gh_jid=7558051) |
-| 🚀 Coinbase | Software Engineer - Customer Agent Interactions System | Remote - Brazil | 6 days ago | [Apply](https://www.coinbase.com/careers/positions/7539703?gh_jid=7539703) |
-| 🚀 Coinbase | Software Engineer, Full Stack (EAA) | Remote - Brazil | 6 days ago | [Apply](https://www.coinbase.com/careers/positions/7584070?gh_jid=7584070) |
-| 🚀 Coinbase | Software Engineer - Full Stack (EAA - Compliance) | Remote - USA | 6 days ago | [Apply](https://www.coinbase.com/careers/positions/6233713?gh_jid=6233713) |
-| 🚀 SpaceX | Software Engineer, Satellite Operations (Starshield) | Hawthorne, CA | 6 days ago | [Apply](https://boards.greenhouse.io/spacex/jobs/8382088002?gh_jid=8382088002) |
-| 🚀 Nuro | Software Engineer, Infrastructure | Mountain View, California (HQ) | 6 days ago | [Apply](https://nuro.ai/careersitem?gh_jid=7540514) |
-| 🚀 SpaceX | Software Engineer, Components Test (Starshield) | Hawthorne, CA | 6 days ago | [Apply](https://boards.greenhouse.io/spacex/jobs/8391434002?gh_jid=8391434002) |
-| Lattice | Software Engineer, Data Platform | Remote - Ontario, Canada | 6 days ago | [Apply](https://lattice.com/job?gh_jid=8434039002) |
-| Lattice | Software Engineer, Data Platform | Remote - British Columbia, Canada | 6 days ago | [Apply](https://lattice.com/job?gh_jid=8434007002) |
-| 🚀 Vercel | Software Engineer, Accounts | Remote - United States | 6 days ago | [Apply](https://job-boards.greenhouse.io/vercel/jobs/5430088004) |
-| 🚀 Vercel | Software Engineer, Accounts | Remote - United States | 6 days ago | [Apply](https://job-boards.greenhouse.io/vercel/jobs/5431123004) |
-| 🚀 Vercel | Software Engineer, AI Gateway | Hybrid - San Francisco, New York City | 6 days ago | [Apply](https://job-boards.greenhouse.io/vercel/jobs/5798406004) |
-| 🚀 Vercel | Software Engineer, AI SDK | Hybrid - San Francisco, New York City | 6 days ago | [Apply](https://job-boards.greenhouse.io/vercel/jobs/5474915004) |
-| 🚀 Vercel | Software Engineer, CDN | Hybrid - San Francisco, New York City | 6 days ago | [Apply](https://job-boards.greenhouse.io/vercel/jobs/5179639004) |
-| 🚀 Vercel | Software Engineer, CDN Security | Remote - United States | 6 days ago | [Apply](https://job-boards.greenhouse.io/vercel/jobs/5473266004) |
-| 🚀 Vercel | Software Engineer, Compute | Remote - United States | 6 days ago | [Apply](https://job-boards.greenhouse.io/vercel/jobs/5551619004) |
-| 🚀 Vercel | Software Engineer, Dashboard | Hybrid - San Francisco, New York City | 6 days ago | [Apply](https://job-boards.greenhouse.io/vercel/jobs/5808568004) |
-| 🚀 Vercel | Software Engineer, Deployment Infrastructure | Hybrid - San Francisco, New York City | 6 days ago | [Apply](https://job-boards.greenhouse.io/vercel/jobs/5633880004) |
-| 🚀 Vercel | Software Engineer, Domains | Remote - United States | 6 days ago | [Apply](https://job-boards.greenhouse.io/vercel/jobs/5813134004) |
-| 🚀 Vercel | Software Engineer, Growth | Hybrid - San Francisco, New York City | 6 days ago | [Apply](https://job-boards.greenhouse.io/vercel/jobs/5613601004) |
-| 🚀 Vercel | Software Engineer, Lua | Remote - United States | 6 days ago | [Apply](https://job-boards.greenhouse.io/vercel/jobs/5661583004) |
-| 🚀 Vercel | Software Engineer, Support Platform | Hybrid - San Francisco | 6 days ago | [Apply](https://job-boards.greenhouse.io/vercel/jobs/5611527004) |
-| 🚀 Vercel | Software Engineer, Workflows | Hybrid - San Francisco, New York City | 6 days ago | [Apply](https://job-boards.greenhouse.io/vercel/jobs/5798416004) |
-| 🚀 Unity Technologies | Software Engineer - Production Verification | Remote, Florida, USA | 6 days ago | [Apply](https://unity.com/careers/positions/7684547?gh_jid=7684547) |
-| 🚀 Roblox | Software Engineer, Ads & Brands | San Mateo, CA, United States | 6 days ago | [Apply](https://careers.roblox.com/jobs/7535750?gh_jid=7535750) |
-| 🔥 Lyft | Software Engineer, Driver Earnings | Seattle, WA | 6 days ago | [Apply](https://app.careerpuck.com/job-board/lyft/job/8367642002?gh_jid=8367642002) |
-| 🚀 SpaceX | Power Systems Engineer (Starship) | Starbase, TX | 6 days ago | [Apply](https://boards.greenhouse.io/spacex/jobs/8450056002?gh_jid=8450056002) |
-| 🚀 SpaceX | Software Engineer, HITL - Top Secret Clearance 🇺🇸 | Hawthorne, CA | 6 days ago | [Apply](https://boards.greenhouse.io/spacex/jobs/8397596002?gh_jid=8397596002) |
-| 🚀 SpaceX | Security Software Engineer - Top Secret Clearance 🇺🇸 | Hawthorne, CA | 6 days ago | [Apply](https://boards.greenhouse.io/spacex/jobs/8306251002?gh_jid=8306251002) |
-| 🚀 Affirm | Software Engineer II, Backend (Identity Decisioning)    | Remote US | 2026-03-04 | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7543978003) |
-| Lattice | Software Engineer, Developer Platform | Remote - Ontario, Canada | 2026-03-04 | [Apply](https://lattice.com/job?gh_jid=8450068002) |
-| Lattice | Software Engineer, Developer Platform | Remote - British Columbia, Canada | 2026-03-04 | [Apply](https://lattice.com/job?gh_jid=8401154002) |
-| 🚀 SpaceX | Software Engineer, Data - Top Secret Clearance (Starlink) 🇺🇸 | Hawthorne, CA | 2026-03-04 | [Apply](https://boards.greenhouse.io/spacex/jobs/8449846002?gh_jid=8449846002) |
-| CircleCI | Software Engineer, Community Engagement | San Francisco, CA | 2026-03-04 | [Apply](http://www.circleci.com/careers/jobs/8318269002/?gh_jid=8318269002) |
-| 🚀 Dropbox | Android Software Engineer, Mobile Experience | Remote - Canada: Select locations | 2026-03-04 | [Apply](https://jobs.dropbox.com/listing/7469391?gh_jid=7469391) |
-| 🚀 Dropbox | Android Software Engineer, Mobile Experience | Remote - US: Select locations | 2026-03-04 | [Apply](https://jobs.dropbox.com/listing/7469388?gh_jid=7469388) |
-| 🚀 Dropbox | Frontend Product Software Engineer, Web DX | Remote - Mexico | 2026-03-04 | [Apply](https://jobs.dropbox.com/listing/7580431?gh_jid=7580431) |
-| 🚀 Dropbox | Fullstack Product Software Engineer | Remote - Canada: Select locations | 2026-03-04 | [Apply](https://jobs.dropbox.com/listing/6330405?gh_jid=6330405) |
-| 🚀 Dropbox | Fullstack Product Software Engineer | Remote - US: Select locations | 2026-03-04 | [Apply](https://jobs.dropbox.com/listing/6330409?gh_jid=6330409) |
-| 🚀 Dropbox | Full Stack Product Software Engineer | Remote - Poland | 2026-03-04 | [Apply](https://jobs.dropbox.com/listing/6449729?gh_jid=6449729) |
-| 🚀 Dropbox | Full Stack Product Software Engineer | Remote - Mexico | 2026-03-04 | [Apply](https://jobs.dropbox.com/listing/7172839?gh_jid=7172839) |
-| 🚀 Dropbox | Fullstack Product Software Engineer, DocSend | Remote - US: Select locations | 2026-03-04 | [Apply](https://jobs.dropbox.com/listing/7344968?gh_jid=7344968) |
-| 🚀 Dropbox | Fullstack Product Software Engineer, DocSend | Remote - Canada: Select locations | 2026-03-04 | [Apply](https://jobs.dropbox.com/listing/7344971?gh_jid=7344971) |
-| 🚀 Dropbox | Full-Stack Product Software Engineer, Search Platform | Remote - Canada: Select locations | 2026-03-04 | [Apply](https://jobs.dropbox.com/listing/7491863?gh_jid=7491863) |
-| 🚀 Dropbox | Full-Stack Product Software Engineer, Search Platform | Remote - US: Select locations | 2026-03-04 | [Apply](https://jobs.dropbox.com/listing/7491860?gh_jid=7491860) |
-| 🚀 Dropbox | Infrastructure Software Engineer | Remote - US: Select locations | 2026-03-04 | [Apply](https://jobs.dropbox.com/listing/6330390?gh_jid=6330390) |
-| 🚀 Dropbox | Infrastructure Software Engineer | Remote - Canada: Select locations | 2026-03-04 | [Apply](https://jobs.dropbox.com/listing/6330388?gh_jid=6330388) |
-| 🚀 Dropbox | Infrastructure Software Engineer, API Platform | Remote - Poland | 2026-03-04 | [Apply](https://jobs.dropbox.com/listing/7387420?gh_jid=7387420) |
-| 🚀 Dropbox | Infrastructure Software Engineer, Data Observability | Remote - Poland | 2026-03-04 | [Apply](https://jobs.dropbox.com/listing/7341950?gh_jid=7341950) |
-| 🚀 Dropbox | iOS Software Engineer, Mobile Infrastructure | Remote - US: All locations | 2026-03-04 | [Apply](https://jobs.dropbox.com/listing/7053876?gh_jid=7053876) |
-| 🚀 Dropbox | iOS Software Engineer, Mobile Infrastructure | Remote - Mexico | 2026-03-04 | [Apply](https://jobs.dropbox.com/listing/7182020?gh_jid=7182020) |
-| 🚀 Dropbox | iOS Software Engineer, Mobile Infrastructure | Remote - Canada: Select locations | 2026-03-04 | [Apply](https://jobs.dropbox.com/listing/7053880?gh_jid=7053880) |
-| 🚀 Unity Technologies | Software Engineer - SyncSketch | Remote, USA | 2026-03-04 | [Apply](https://unity.com/careers/positions/7435113?gh_jid=7435113) |
-| 🚀 Unity Technologies | Software Engineer - SyncSketch/ Développeur(se) Logiciel | Remote, Canada | 2026-03-04 | [Apply](https://unity.com/careers/positions/7523945?gh_jid=7523945) |
-| StockX | Software Engineer - Core Services | Detroit, MI | 2026-03-04 | [Apply](https://job-boards.greenhouse.io/stockx/jobs/8376615002) |
-| Grafana Labs |  Software Engineer - Platform InfraCore \| USA \| Remote   | United States (Remote) | 2026-03-04 | [Apply](https://job-boards.greenhouse.io/grafanalabs/jobs/5809023004) |
-| Grafana Labs |  Software Engineer - Platform InfraCore \| USA \| Remote   | Canada (Remote) | 2026-03-04 | [Apply](https://job-boards.greenhouse.io/grafanalabs/jobs/5809025004) |
-| 🔥 Lyft | Software Engineer, Data Platform | San Francisco, CA | 2026-03-04 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8448176002?gh_jid=8448176002) |
-| 🚀 SpaceX | Software Engineer, CDN  (Starlink) | Redmond, WA | 2026-03-04 | [Apply](https://boards.greenhouse.io/spacex/jobs/8448505002?gh_jid=8448505002) |
-| 🚀 Cloudflare | Systems Engineer, Frontend | In-Office | 2026-03-04 | [Apply](https://boards.greenhouse.io/cloudflare/jobs/7436794?gh_jid=7436794) |
-| 🚀 Cloudflare | Software Engineer - Platforms & Productivity | In-Office | 2026-03-04 | [Apply](https://boards.greenhouse.io/cloudflare/jobs/6972536?gh_jid=6972536) |
-| 🚀 Nuro | Software Engineer, Middleware | Mountain View, California (HQ) | 2026-03-04 | [Apply](https://nuro.ai/careersitem?gh_jid=6188874) |
-| 🚀 Nuro | Software Engineer, Onboard Systems | Mountain View, California (HQ) | 2026-03-04 | [Apply](https://nuro.ai/careersitem?gh_jid=6698739) |
-| 🚀 Nuro | Software Engineer, Sensor Platform | Mountain View, California (HQ) | 2026-03-04 | [Apply](https://nuro.ai/careersitem?gh_jid=6393147) |
-| Fastly | Systems Engineer, Identity and Access Management | Denver, CO; New York City, NY; San Francisco, CA | 2026-03-04 | [Apply](https://www.fastly.com/about/jobs/apply?gh_jid=7669557) |
-| 🚀 Nuro | Software Engineer, Routing | Mountain View, California (HQ) | 2026-03-03 | [Apply](https://nuro.ai/careersitem?gh_jid=7482347) |
-| Abnormal Security | Software Engineer 2 - Message Security Detection | Remote - Canada | 2026-03-03 | [Apply](https://abnormal.ai/careers/jobs/6655645003?gh_jid=6655645003) |
-| Abnormal Security | Software Engineer 2 - Message Security Detection | Remote - USA | 2026-03-03 | [Apply](https://abnormal.ai/careers/jobs/6655554003?gh_jid=6655554003) |
-| 🚀 Lucid | GTM Systems Engineer (AI & Automation) | Remote, US | 2026-03-03 | [Apply](https://job-boards.greenhouse.io/lucidsoftware/jobs/5778429004) |
-| Abnormal Security | Software Engineer 1, Product Engineering - Identity Security | Hybrid - San Francisco, CA, USA | 2026-03-03 | [Apply](https://abnormal.ai/careers/jobs/7491522003?gh_jid=7491522003) |
-| Abnormal Security | Software Engineer 2 - Backend - Behavioral Security Products | Remote - Singapore | 2026-03-03 | [Apply](https://abnormal.ai/careers/jobs/7540592003?gh_jid=7540592003) |
-| Abnormal Security | Software Engineer 2 - Backend - Behavioral Security Products | Remote - UK | 2026-03-03 | [Apply](https://abnormal.ai/careers/jobs/6593836003?gh_jid=6593836003) |
-| Abnormal Security | Software Engineer 2, Platform Security | Remote - USA | 2026-03-03 | [Apply](https://abnormal.ai/careers/jobs/7516751003?gh_jid=7516751003) |
-| Abnormal Security | Software Engineer 2, Product Engineering - Identity Security | Remote - USA | 2026-03-03 | [Apply](https://abnormal.ai/careers/jobs/7491487003?gh_jid=7491487003) |
-| Abnormal Security | Software Engineer II - Backend  | Hybrid - Bangalore, India | 2026-03-03 | [Apply](https://abnormal.ai/careers/jobs/6592675003?gh_jid=6592675003) |
-| Abnormal Security | Software Engineer II - Fullstack | Hybrid - Bangalore, India | 2026-03-03 | [Apply](https://abnormal.ai/careers/jobs/6577843003?gh_jid=6577843003) |
-| Abnormal Security | Software Engineer II - Message Infrastructure | Remote - Canada | 2026-03-03 | [Apply](https://abnormal.ai/careers/jobs/7593031003?gh_jid=7593031003) |
-| Abnormal Security | Software Engineer II - Message Infrastructure | Remote - USA | 2026-03-03 | [Apply](https://abnormal.ai/careers/jobs/7589246003?gh_jid=7589246003) |
-| 🚀 Plaid | Software Engineer | Seattle, WA | 2026-03-02 | [Apply](https://jobs.lever.co/plaid/f455a60a-6ea0-4d1b-890b-5f7869192c5f) |
-| 🚀 Palantir | Forward Deployed Software Engineer - Tactical Edge | Washington, D.C. | 2026-03-02 | [Apply](https://jobs.lever.co/palantir/3d0d9d92-0321-4459-a17d-fa1a76636a43) |
-| Opendoor | Software Engineer – Backend, Pricing | Seattle, Washington, United States | 2026-03-02 | [Apply](https://www.opendoor.com/careers/open-positions?gh_jid=4575823006) |
-| 🚀 SoFi | Software Engineer, Member AI Features | WA - Seattle | 2026-03-02 | [Apply](https://sofi.com/careers/job/7645856003?gh_jid=7645856003) |
-| 🚀 SpaceX | RF Silicon Software Engineer (Starlink) | Redmond, WA | 2026-03-02 | [Apply](https://boards.greenhouse.io/spacex/jobs/8439627002?gh_jid=8439627002) |
-| 🚀 Datadog | Enablement Systems Engineer | New York, New York, USA | 2026-03-02 | [Apply](https://careers.datadoghq.com/detail/7538717/?gh_jid=7538717) |
-| 🚀 Unity Technologies | Software Engineer - Production Verification | Remote, United Kingdom | 2026-03-02 | [Apply](https://unity.com/careers/positions/7669656?gh_jid=7669656) |
-| 🚀 Figma | Software Engineer, Translations Platform | San Francisco, CA • New York, NY • United States | 2026-03-02 | [Apply](https://boards.greenhouse.io/figma/jobs/5759501004?gh_jid=5759501004) |
-| 🚀 Unity Technologies | Développeur(se) logiciel – Vérification en production  / Software Developer - Production Verification | Remote, Quebec, Canada | 2026-03-02 | [Apply](https://unity.com/careers/positions/7669641?gh_jid=7669641) |
-| LaunchDarkly | SDK Software Engineer, AI | Remote - US | 2026-03-02 | [Apply](https://job-boards.greenhouse.io/launchdarkly/jobs/7647797003) |
-| 🚀 Marqeta | Software Engineer II | Toronto, Canada | 2026-03-02 | [Apply](https://job-boards.greenhouse.io/marqeta/jobs/6183568) |
-| 🚀 Airtable | Software Engineer, Compute (8+ YOE) | San Francisco, CA; New York, NY; Remote - US | 2026-03-02 | [Apply](https://job-boards.greenhouse.io/airtable/jobs/8442397002) |
-| Scopely | Software Engineer - Web/Fullstack | US - Sunnyvale, United States | 2026-03-02 | [Apply](https://job-boards.greenhouse.io/scopely/jobs/5105578008) |
-| 🚀 Figma | Software Engineer, Developer Experience | San Francisco, CA • New York, NY • United States | 2026-02-27 | [Apply](https://boards.greenhouse.io/figma/jobs/5790627004?gh_jid=5790627004) |
-| 🚀 SpaceX | Security Software Engineer, Applied Computing (Starshield) | Washington, DC | 2026-02-27 | [Apply](https://boards.greenhouse.io/spacex/jobs/8441008002?gh_jid=8441008002) |
-| 🚀 Affirm | Software Engineer II, Backend (Credit Decisioning)  | Remote US | 2026-02-27 | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7597920003) |
-| 🚀 Affirm | Software Engineer II, Backend (Credit Decisioning) | Remote US | 2026-02-27 | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7550577003) |
-| 🚀 Affirm | Software Engineer, Backend (Marketplace Performance) | Remote US | 2026-02-27 | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7579879003) |
-| CircleCI | Full-Stack Software Engineer, Web Experiences  | Toronto, Ontario | 2026-02-27 | [Apply](http://www.circleci.com/careers/jobs/8420901002/?gh_jid=8420901002) |
-| 🔥 Lyft | Software Engineer (Backend), Growth Platforms | Toronto, Canada | 2026-02-27 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8421508002?gh_jid=8421508002) |
-| 🚀 Unity Technologies | Software Engineer, Asset Store Content Operations | Remote, Lithuania | 2026-02-27 | [Apply](https://unity.com/careers/positions/7634404?gh_jid=7634404) |
-| 🚀 Ripple | Software Engineer II | San Francisco, CA, United States | 2026-02-27 | [Apply](https://ripple.com/careers/all-jobs/job/7654753?gh_jid=7654753) |
-| Opendoor | Software Engineer, Financial Systems | Seattle, Washington, United States | 2026-02-26 | [Apply](https://www.opendoor.com/careers/open-positions?gh_jid=4656378006) |
-| Opendoor | Software Engineer, Financial Systems | Toronto | 2026-02-26 | [Apply](https://www.opendoor.com/careers/open-positions?gh_jid=4643080006) |
-| Opendoor | Software Engineer - FullStack | Seattle, Washington, United States | 2026-02-26 | [Apply](https://www.opendoor.com/careers/open-positions?gh_jid=4643074006) |
-| Opendoor | Software Engineer, MLOps - Pricing  | Seattle, Washington, United States | 2026-02-26 | [Apply](https://www.opendoor.com/careers/open-positions?gh_jid=4648098006) |
-| Opendoor | Software Engineer, Pricing MLOps | Seattle, Washington, United States | 2026-02-26 | [Apply](https://www.opendoor.com/careers/open-positions?gh_jid=4648092006) |
-| Opendoor | Software Engineer, Security Engineering | Toronto | 2026-02-26 | [Apply](https://www.opendoor.com/careers/open-positions?gh_jid=4652235006) |
-| Opendoor | Software Engineer, Security Engineering | Office - Washington-Seattle | 2026-02-26 | [Apply](https://www.opendoor.com/careers/open-positions?gh_jid=4649154006) |
-| 🚀 SpaceX | Software Engineer, Product Development (Starshield) | Hawthorne, CA | 2026-02-26 | [Apply](https://boards.greenhouse.io/spacex/jobs/8436728002?gh_jid=8436728002) |
-| 🚀 Discord | Rust/C++ Software Engineer | San Francisco Bay Area | 2026-02-26 | [Apply](https://job-boards.greenhouse.io/discord/jobs/8177727002) |
-| 🚀 Unity Technologies | Développeur(se) logiciel, Exécution des commandes  / Software Developer, Fulfillment | Montreal, Canada | 2026-02-26 | [Apply](https://unity.com/careers/positions/7568973?gh_jid=7568973) |
-| 🚀 Unity Technologies | Développeur(se) logiciel – Vérification en production  / Software Developer - Production Verification | Montreal, Canada | 2026-02-26 | [Apply](https://unity.com/careers/positions/7579024?gh_jid=7579024) |
-| 🚀 Upstart | Software Engineer II, Verifications Decisioning | United States \| Remote | 2026-02-25 | [Apply](https://careers.upstart.com/jobs?gh_jid=7594776) |
-| 🔥 Lyft | Software Engineer, AI Entries | Toronto, Canada | 2026-02-25 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8437149002?gh_jid=8437149002) |
-| 🚀 Roblox | [2026] Software Engineer, Creator - Early Career | San Mateo, CA, United States | 2026-02-25 | [Apply](https://careers.roblox.com/jobs/7557909?gh_jid=7557909) |
-| 🚀 SpaceX | IT Systems Engineer, DevOps | Redmond, WA | 2026-02-25 | [Apply](https://boards.greenhouse.io/spacex/jobs/8417752002?gh_jid=8417752002) |
-| CircleCI | Software Engineer, Execution | Toronto, Ontario | 2026-02-25 | [Apply](http://www.circleci.com/careers/jobs/8032254002/?gh_jid=8032254002) |
-| 🚀 SpaceX | Software Engineer (Components) | Hawthorne, CA | 2026-02-25 | [Apply](https://boards.greenhouse.io/spacex/jobs/8215236002?gh_jid=8215236002) |
-| 🚀 Pinterest | Software Engineer, Backend | Mexico City, MX; Remote, MX | 2026-02-25 | [Apply](https://www.pinterestcareers.com/jobs/?gh_jid=5039778) |
-| 🚀 Pinterest |  Software Engineer II, Full Stack | Mexico City, MX; Remote, MX | 2026-02-25 | [Apply](https://www.pinterestcareers.com/jobs/?gh_jid=6142084) |
-| 🚀 SoFi | Software Engineer, Money Movement | NY - New York City | 2026-02-25 | [Apply](https://sofi.com/careers/job/7638994003?gh_jid=7638994003) |
-| 🔥 Lyft | Software Engineer, Backend | Toronto, Canada | 2026-02-25 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8434361002?gh_jid=8434361002) |
-| 🔥 Lyft | Software Engineer, Backend | Toronto, Canada | 2026-02-25 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8437151002?gh_jid=8437151002) |
-| 🔥 Lyft | Software Engineer, Pricing | Toronto, Canada | 2026-02-25 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8396751002?gh_jid=8396751002) |
-| Checkr | Backend Software Engineer II | San Francisco, California, United States | 2026-02-24 | [Apply](https://job-boards.greenhouse.io/checkr/jobs/7438937) |
-| Checkr | Software Engineer II | San Francisco, California, United States | 2026-02-24 | [Apply](https://job-boards.greenhouse.io/checkr/jobs/7296759) |
-| 🚀 SpaceX | Software Engineer, Flight Software (Starshield) | Hawthorne, CA | 2026-02-24 | [Apply](https://boards.greenhouse.io/spacex/jobs/8322723002?gh_jid=8322723002) |
-| 🚀 SpaceX | Software Engineer (Starshield) - Top Secret Clearance 🇺🇸 | Hawthorne, CA | 2026-02-24 | [Apply](https://boards.greenhouse.io/spacex/jobs/8387886002?gh_jid=8387886002) |
-| 🚀 SpaceX | Software Engineer (Starshield) | Hawthorne, CA | 2026-02-24 | [Apply](https://boards.greenhouse.io/spacex/jobs/8385191002?gh_jid=8385191002) |
-| 🚀 Affirm | Software Engineer I, Back-end (Collections) | Remote Poland | 2026-02-24 | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7538088003) |
-| 🚀 Affirm | Software Engineer I, Back-end (Collections) | Remote Spain | 2026-02-24 | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7538090003) |
-| 🚀 Affirm | Software Engineer I, Backend (Consumer Engineering)  | Remote Spain | 2026-02-24 | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7617853003) |
-| 🚀 Affirm | Software Engineer I, Full Stack (Consumer Engineering) | Remote Spain | 2026-02-24 | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7609024003) |
-| 🚀 Affirm | Software Engineer II, Backend (Consumer Engineering) | Remote Spain | 2026-02-24 | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7615040003) |
-| 🚀 Grammarly | Software Engineer, Frontend | San Francisco or Remote (US, Canada, Argentina, Brazil, Mexico) | 2026-02-24 | [Apply](https://job-boards.greenhouse.io/grammarly/jobs/7271992) |
-| 🚀 Airtable | Software Engineer, Product Backend (2-8 YOE) | San Francisco, CA; New York, NY; Remote (Seattle, WA only) | 2026-02-24 | [Apply](https://job-boards.greenhouse.io/airtable/jobs/7845291002) |
-| 🚀 Airtable | Software Engineer, Product Frontend (2-8 YOE) | San Francisco, CA; New York, NY; Remote (Seattle, WA only) | 2026-02-24 | [Apply](https://job-boards.greenhouse.io/airtable/jobs/7845265002) |
-| 🚀 Airtable | Software Engineer, Product Backend (8+ YOE) | San Francisco, CA; Remote (Seattle, WA only) | 2026-02-24 | [Apply](https://job-boards.greenhouse.io/airtable/jobs/7845287002) |
-| 🚀 SoFi | Full-Stack Software Engineer, Benefits and Rewards | CA - San Francisco | 2026-02-23 | [Apply](https://sofi.com/careers/job/7581360003?gh_jid=7581360003) |
-| 🚀 SoFi | Software Engineer, Loans Originations | Helena, Montana | 2026-02-23 | [Apply](https://sofi.com/careers/job/7616182003?gh_jid=7616182003) |
-| 🚀 SpaceX | Power Systems Engineer | Bastrop, TX | 2026-02-23 | [Apply](https://boards.greenhouse.io/spacex/jobs/8401210002?gh_jid=8401210002) |
-| Yugabyte | Software Engineer | United States | 2026-02-23 | [Apply](https://job-boards.greenhouse.io/yugabyte/jobs/4656120006) |
-| ClickHouse | Software Engineer - Database Integrations | United States (remote) | 2026-02-20 | [Apply](https://job-boards.greenhouse.io/clickhouse/jobs/5765673004) |
-| ClickHouse | Software Engineer - Database Integrations | Canada (remote) | 2026-02-20 | [Apply](https://job-boards.greenhouse.io/clickhouse/jobs/5765672004) |
-| ClickHouse | Software Engineer - Database Integrations | Germany (remote) | 2026-02-20 | [Apply](https://job-boards.greenhouse.io/clickhouse/jobs/5765671004) |
-| 🚀 Lucid | GTM Systems Engineer (AI & Automation) | Salt Lake City, UT | 2026-02-20 | [Apply](https://job-boards.greenhouse.io/lucidsoftware/jobs/5778437004) |
-| 🚀 Lucid | GTM Systems Engineer (AI & Automation) | Raleigh, NC | 2026-02-20 | [Apply](https://job-boards.greenhouse.io/lucidsoftware/jobs/5778431004) |
-| Sumo Logic | Software Engineer I - SRE | Noida, Uttar Pradesh, India | 2026-02-20 | [Apply](https://job-boards.greenhouse.io/sumologic/jobs/7407235) |
-| 🚀 Roblox | [2026 Canada] Software Engineer, Geometry - Early Career | Vancouver, British Columbia, Canada | 2026-02-19 | [Apply](https://careers.roblox.com/jobs/7558821?gh_jid=7558821) |
-| 🚀 Roblox | Systems Software Engineer - Game Engine Network (C++) | San Mateo, CA, United States | 2026-02-19 | [Apply](https://careers.roblox.com/jobs/7561739?gh_jid=7561739) |
-| 🚀 Nuro | Software Engineer, Onboard Infrastructure | Mountain View, California (HQ) | 2026-02-19 | [Apply](https://nuro.ai/careersitem?gh_jid=7638808) |
-| 🚀 Nuro | Software Engineer, Offboard Infrastructure | Mountain View, California (HQ) | 2026-02-19 | [Apply](https://nuro.ai/careersitem?gh_jid=7638789) |
-| 🚀 Databricks | Software Engineer - GenAI inference  | San Francisco, California | 2026-02-19 | [Apply](https://databricks.com/company/careers/open-positions/job?gh_jid=8202670002) |
-| 🚀 SpaceX | Software Engineer (Vehicle Engineering) | Hawthorne, CA | 2026-02-18 | [Apply](https://boards.greenhouse.io/spacex/jobs/8397542002?gh_jid=8397542002) |
-| 🚀 SpaceX | Software Engineer, Tracking (Starshield) | Hawthorne, CA | 2026-02-18 | [Apply](https://boards.greenhouse.io/spacex/jobs/8414648002?gh_jid=8414648002) |
-| 🚀 Cloudflare | Software Engineer (Backend) | In-Office | 2026-02-17 | [Apply](https://boards.greenhouse.io/cloudflare/jobs/7603643?gh_jid=7603643) |
-| 🚀 Nuro | Software Engineer, Video Streaming | Mountain View, California (HQ) | 2026-02-17 | [Apply](https://nuro.ai/careersitem?gh_jid=7481634) |
-| Postman | Software Engineer - Frontend, Performance and Monitoring | Bengaluru, Karnataka, India | 2026-02-17 | [Apply](https://job-boards.greenhouse.io/postman/jobs/7583237003) |
-| ClickHouse | Cloud Software Engineer - Identity and Access Management | Canada (remote) | 2026-02-13 | [Apply](https://job-boards.greenhouse.io/clickhouse/jobs/5803693004) |
-| ClickHouse | Cloud Software Engineer - Identity and Access Management | Netherlands (remote) | 2026-02-13 | [Apply](https://job-boards.greenhouse.io/clickhouse/jobs/5803692004) |
-| ClickHouse | Cloud Software Engineer - Identity and Access Management | United States (remote) | 2026-02-13 | [Apply](https://job-boards.greenhouse.io/clickhouse/jobs/5766229004) |
-| 🚀 Scale AI | Software Engineer - New Grad | San Francisco, CA | 2026-02-12 | [Apply](https://job-boards.greenhouse.io/scaleai/jobs/4605996005) |
-| 🚀 SpaceX | Full Stack Software Engineer (Components) | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8421359002?gh_jid=8421359002) |
-| 🚀 SpaceX | Application Software Engineer, Data | Starbase, TX | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8420526002?gh_jid=8420526002) |
-| 🚀 SpaceX | Antenna Software Engineer, Satellites (Starlink) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8357946002?gh_jid=8357946002) |
-| 🚀 SpaceX | Application Software Engineer | Starbase, TX | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8310481002?gh_jid=8310481002) |
-| 🚀 SpaceX | Application Software Engineer | Bastrop, TX | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8211822002?gh_jid=8211822002) |
-| 🚀 SpaceX | Application Software Engineer | Cape Canaveral, FL | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8393346002?gh_jid=8393346002) |
-| 🚀 SpaceX | Application Software Engineer | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8211826002?gh_jid=8211826002) |
-| 🚀 SpaceX | Application Software Engineer | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8402778002?gh_jid=8402778002) |
-| 🚀 SpaceX | Application Software Engineer, Data | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8371372002?gh_jid=8371372002) |
-| 🚀 SpaceX | Application Software Engineer, Data - Top Secret Clearance 🇺🇸 | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8211824002?gh_jid=8211824002) |
-| 🚀 SpaceX | Avionics Systems Engineer (Starship)  | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8377628002?gh_jid=8377628002) |
-| 🚀 SpaceX | Avionics Systems Engineer (Starship)    | Starbase, TX | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8356336002?gh_jid=8356336002) |
-| 🚀 SpaceX | Backend Software Engineer, GNC (Starlink)  | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8398679002?gh_jid=8398679002) |
-| 🚀 SpaceX | Embedded Software Engineer, OS/Platform  (Starlink) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8402489002?gh_jid=8402489002) |
-| 🚀 SpaceX | Embedded Software Engineer (Starlink)  | Bastrop, TX | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8368715002?gh_jid=8368715002) |
-| 🚀 SpaceX | Fluids Systems Engineer, Solar Cell Factory (Starlink) | Bastrop, TX | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8346155002?gh_jid=8346155002) |
-| 🚀 SpaceX | Full Stack Software Engineer (Application Software) | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8300183002?gh_jid=8300183002) |
-| 🚀 SpaceX | Full Stack Software Engineer (Build Reliability)  | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8358022002?gh_jid=8358022002) |
-| 🚀 SpaceX | Full Stack Software Engineer, Constellation Tools (Starlink) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8398604002?gh_jid=8398604002) |
-| 🚀 SpaceX | Full Stack Software Engineer (Starlink Ground Network) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8211878002?gh_jid=8211878002) |
-| 🚀 SpaceX | Full Stack Software Engineer (Starshield) | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8365490002?gh_jid=8365490002) |
-| 🚀 SpaceX | Full Stack Software Engineer - Top Secret Clearance 🇺🇸 | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8397609002?gh_jid=8397609002) |
-| 🚀 SpaceX | GNC Software Engineer (Falcon) | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8359233002?gh_jid=8359233002) |
-| 🚀 SpaceX | Ground Software Engineer, LabVIEW (Falcon & Dragon) | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8306482002?gh_jid=8306482002) |
-| 🚀 SpaceX | High Performance Computing (HPC) Systems Engineer | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8393331002?gh_jid=8393331002) |
-| 🚀 SpaceX | IT Systems Engineer, Launch | Starbase, TX | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8233514002?gh_jid=8233514002) |
-| 🚀 SpaceX | OS/Platform Software Engineer (Starlink) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8402452002?gh_jid=8402452002) |
-| 🚀 SpaceX | Power Systems Engineer (Starship Avionics) | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8355513002?gh_jid=8355513002) |
-| 🚀 SpaceX | Quality Systems Engineer (Starlink Aviation) | Woodinville, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8372252002?gh_jid=8372252002) |
-| 🚀 SpaceX | Satellite Systems Software Engineer (Starlink) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8395341002?gh_jid=8395341002) |
-| 🚀 SpaceX | Security Software Engineer | Bastrop, TX | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8420836002?gh_jid=8420836002) |
-| 🚀 SpaceX | Security Software Engineer | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8380527002?gh_jid=8380527002) |
-| 🚀 SpaceX | Security Software Engineer | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8380536002?gh_jid=8380536002) |
-| 🚀 SpaceX | Security Software Engineer (Starshield) | Washington, DC | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8225074002?gh_jid=8225074002) |
-| 🚀 SpaceX | Security Software Engineer (Starshield) | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8392887002?gh_jid=8392887002) |
-| 🚀 SpaceX | Software Engineer | McGregor, TX | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8324788002?gh_jid=8324788002) |
-| 🚀 SpaceX | Software Engineer, Additive Manufacturing (Raptor) | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8327721002?gh_jid=8327721002) |
-| 🚀 SpaceX | Software Engineer, Beam Planning (Starlink)    | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8284531002?gh_jid=8284531002) |
-| 🚀 SpaceX | Software Engineer, Beam Planning (Starlink)    | Sunnyvale, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8373117002?gh_jid=8373117002) |
-| 🚀 SpaceX | Software Engineer, Collision Avoidance (Starshield) | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8397683002?gh_jid=8397683002) |
-| 🚀 SpaceX | Software Engineer, C++ (Starlink) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8324395002?gh_jid=8324395002) |
-| 🚀 SpaceX | Software Engineer, C++ - Top Secret Clearance  🇺🇸 | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8377056002?gh_jid=8377056002) |
-| 🚀 SpaceX | Software Engineer, Data - Top Secret Clearance 🇺🇸 | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8397673002?gh_jid=8397673002) |
-| 🚀 SpaceX | Software Engineer (Direct To Cell) | Sunnyvale, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8364374002?gh_jid=8364374002) |
-| 🚀 SpaceX | Software Engineer (Direct To Cell) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8390870002?gh_jid=8390870002) |
-| 🚀 SpaceX | Software Engineer, Displays Software (Starship) | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8345913002?gh_jid=8345913002) |
-| 🚀 SpaceX | Software Engineer, Embedded Software (Starlink) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8398552002?gh_jid=8398552002) |
-| 🚀 SpaceX | Software Engineer, Flight Software (Starlink) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8398447002?gh_jid=8398447002) |
-| 🚀 SpaceX | Software Engineer, Flight Software (Starship) | Starbase, TX | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8208339002?gh_jid=8208339002) |
-| 🚀 SpaceX | Software Engineer, Flight Software (Starship) | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8208238002?gh_jid=8208238002) |
-| 🚀 SpaceX | Software Engineer, Geospatial Data (Starshield) | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8389619002?gh_jid=8389619002) |
-| 🚀 SpaceX | Software Engineer, GNC Simulations (Starlink) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8395326002?gh_jid=8395326002) |
-| 🚀 SpaceX | Software Engineer, Hardware Test & Automation (Optical Payloads) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8211187002?gh_jid=8211187002) |
-| 🚀 SpaceX | Software Engineer, Hardware Test & Automation (Starlink)    | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8316301002?gh_jid=8316301002) |
-| 🚀 SpaceX | Software Engineer, High Performance Computing | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8365469002?gh_jid=8365469002) |
-| 🚀 SpaceX | Software Engineer - Mechanical/Thermal Tooling, Satellites (Starlink) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8391468002?gh_jid=8391468002) |
-| 🚀 SpaceX | Software Engineer (Network Performance) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8391111002?gh_jid=8391111002) |
-| 🚀 SpaceX | Software Engineer, Power Systems Controls (Starlink) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8395307002?gh_jid=8395307002) |
-| 🚀 SpaceX | Software Engineer, Propulsion Simulation & Data Analysis | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8213250002?gh_jid=8213250002) |
-| 🚀 SpaceX | Software Engineer, Satellite Systems (Starshield) | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8308587002?gh_jid=8308587002) |
-| 🚀 SpaceX | Software Engineer, Simulations (Application Software) | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8330100002?gh_jid=8330100002) |
-| 🚀 SpaceX | Software Engineer (Special Projects) - Top Secret Clearance 🇺🇸 | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8306500002?gh_jid=8306500002) |
-| 🚀 SpaceX | Software Engineer (Starlink) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8406816002?gh_jid=8406816002) |
-| 🚀 SpaceX | Software Engineer (Starlink) | Bastrop, TX | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8379301002?gh_jid=8379301002) |
-| 🚀 SpaceX | Software Engineer (Starlink Ground Network) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8342599002?gh_jid=8342599002) |
-| 🚀 SpaceX | Software Engineer, Starlink Growth | Bastrop, TX | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8403929002?gh_jid=8403929002) |
-| 🚀 SpaceX | Software Engineer, Starlink Network  | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8324397002?gh_jid=8324397002) |
-| 🚀 SpaceX | Software Engineer (Starship Quality) | Starbase, TX | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8220138002?gh_jid=8220138002) |
-| 🚀 SpaceX | Software Engineer, Test Engineering and Operations | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8224317002?gh_jid=8224317002) |
-| 🚀 SpaceX | Software Engineer (Thermal & Fluid Analysis)  | Starbase, TX | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8222759002?gh_jid=8222759002) |
-| 🚀 SpaceX | Systems Engineer, Flight Termination System (Starship) | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8391901002?gh_jid=8391901002) |
-| 🚀 SpaceX | Wi-Fi Software Engineer (Starlink)  | Bastrop, TX | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8379209002?gh_jid=8379209002) |
-| 🚀 Figma | Software Engineer, Production Engineering | San Francisco, CA • New York, NY • United States | 2026-02-12 | [Apply](https://boards.greenhouse.io/figma/jobs/5551649004?gh_jid=5551649004) |
-| Alchemy | Software Engineer (Backend) - Distributed Systems  | New York, NY,  San Francisco, CA | 2026-02-11 | [Apply](https://job-boards.greenhouse.io/alchemy/jobs/4648515005) |
-| 🚀 Nuro | Software Engineer, AI Platform - New Grad | Mountain View, California (HQ) | 2026-02-10 | [Apply](https://nuro.ai/careersitem?gh_jid=7351066) |
-| 🚀 Nuro | Software Engineer, Autonomy-New Grad | Mountain View, California (HQ) | 2026-02-10 | [Apply](https://nuro.ai/careersitem?gh_jid=6932596) |
-| 🚀 Nuro | Software Engineer, Distributed Compute System | Mountain View, California (HQ) | 2026-02-10 | [Apply](https://nuro.ai/careersitem?gh_jid=7583621) |
-| 🚀 Nuro | Software Engineer, ML Infrastructure, Optimization | Mountain View, California (HQ) | 2026-02-10 | [Apply](https://nuro.ai/careersitem?gh_jid=7446303) |
-| 🚀 Nuro | Software Engineer, Networking & Real-Time Systems | Mountain View, California (HQ) | 2026-02-10 | [Apply](https://nuro.ai/careersitem?gh_jid=7481633) |
-| 🚀 Nuro | Software Engineer, Ride-Hailing Product | Mountain View, California (HQ) | 2026-02-10 | [Apply](https://nuro.ai/careersitem?gh_jid=7463764) |
-| 🚀 Discord | Software Engineer, Data Platform | San Francisco Bay Area | 2026-02-09 | [Apply](https://job-boards.greenhouse.io/discord/jobs/8396927002) |
-| 🚀 Reddit | Android Software Engineer, Ad Formats | Chicago, IL | 2026-02-09 | [Apply](https://job-boards.greenhouse.io/reddit/jobs/7415003) |
-| 🚀 Reddit | Android Software Engineer, Ad Formats | Remote - United States | 2026-02-09 | [Apply](https://job-boards.greenhouse.io/reddit/jobs/7415052) |
-| 🚀 Reddit | Android Software Engineer, Ad Formats | New York City, NY | 2026-02-09 | [Apply](https://job-boards.greenhouse.io/reddit/jobs/7415013) |
-| 🚀 Reddit | Android Software Engineer, Ad Formats | San Francisco, CA | 2026-02-09 | [Apply](https://job-boards.greenhouse.io/reddit/jobs/7414993) |
-| 🚀 Reddit | iOS Software Engineer, Ad Formats | Chicago, IL | 2026-02-09 | [Apply](https://job-boards.greenhouse.io/reddit/jobs/7414842) |
-| 🚀 Reddit | iOS Software Engineer, Ad Formats | Remote - United States | 2026-02-09 | [Apply](https://job-boards.greenhouse.io/reddit/jobs/7415041) |
-| 🚀 Reddit | iOS Software Engineer, Ad Formats | New York City, NY | 2026-02-09 | [Apply](https://job-boards.greenhouse.io/reddit/jobs/7414849) |
-| 🚀 Reddit | Software Engineer | Remote - Ontario, Canada | 2026-02-09 | [Apply](https://job-boards.greenhouse.io/reddit/jobs/6909093) |
-| 🚀 Reddit | Software Engineer, Ads | Remote - Ontario, Canada | 2026-02-09 | [Apply](https://job-boards.greenhouse.io/reddit/jobs/6512458) |
-| 🚀 Reddit | Software Engineer, Ads | Remote - United States | 2026-02-09 | [Apply](https://job-boards.greenhouse.io/reddit/jobs/6469397) |
-| 🚀 Unity Technologies | Développeur(euse) logiciel  / Software Developer | Montreal, Canada | 2026-02-09 | [Apply](https://unity.com/careers/positions/7568977?gh_jid=7568977) |
-| 🚀 Instacart | Software Engineer II, Marketing Enablement & Technology | United States - Remote | 2026-02-08 | [Apply](https://instacart.careers/job/?gh_jid=7450259) |
-| Postman | Frontend Software Engineer, Growth Engineering | San Francisco, California, United States | 2026-02-04 | [Apply](https://job-boards.greenhouse.io/postman/jobs/7359054003) |
-| LaunchDarkly | SDK Software Engineer | Remote - US | 2026-02-04 | [Apply](https://job-boards.greenhouse.io/launchdarkly/jobs/7566398003) |
-| LaunchDarkly | Backend Software Engineer, Feature Management | Remote - US | 2026-02-04 | [Apply](https://job-boards.greenhouse.io/launchdarkly/jobs/6671329003) |
-| 🚀 Airtable | Software Engineer, Observability | San Francisco, CA; New York, NY; Remote (Seattle, WA only) | 2026-02-03 | [Apply](https://job-boards.greenhouse.io/airtable/jobs/8400374002) |
-| 🚀 Airtable | Software Engineer, Infrastructure (2-8 YOE) | San Francisco, CA; New York, NY; Remote - US (Seattle, WA only) | 2026-02-03 | [Apply](https://job-boards.greenhouse.io/airtable/jobs/8400373002) |
-| 🚀 Airtable | Software Engineer, Infrastructure (8+ YOE) | San Francisco, CA; New York, NY; Remote - US (Seattle, WA only) | 2026-02-03 | [Apply](https://job-boards.greenhouse.io/airtable/jobs/8400388002) |
-| 🚀 Discord | Software Engineer - Realtime Infrastructure | San Francisco Bay Area | 2026-02-03 | [Apply](https://job-boards.greenhouse.io/discord/jobs/8328560002) |
-| 🚀 Twitch | Software Engineer | Seattle, WA | 2026-02-02 | [Apply](https://job-boards.greenhouse.io/twitch/jobs/8186269002) |
-| 🔥 Lyft | Software Engineer, Data Platforms | Toronto, Canada | 2026-01-30 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8398591002?gh_jid=8398591002) |
-| Alchemy | Software Engineer - Solutions | New York, New York, United States, San Francisco, California, United States | 2026-01-30 | [Apply](https://job-boards.greenhouse.io/alchemy/jobs/4538329005) |
-| SingleStore | Software Engineer (AI Platforms) | India | 2026-01-29 | [Apply](https://job-boards.greenhouse.io/singlestore/jobs/7573638) |
-| 🚀 Palantir | Software Engineer - Defense Applications | Washington, D.C. | 2026-01-26 | [Apply](https://jobs.lever.co/palantir/f7dbfdf1-0bb1-4c11-ac15-6a139cee3410) |
-| 🔥 Lyft | Software Engineer, Server | Toronto, Canada | 2026-01-26 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8391483002?gh_jid=8391483002) |
-| Mercury | Software Engineer - Product | San Francisco, CA, New York, NY, Portland, OR, or Remote within Canada or United States | 2026-01-22 | [Apply](https://job-boards.greenhouse.io/mercury/jobs/5267749004) |
-| Imply | Software Engineer (Remote) | Burlingame, California, United States | 2026-01-22 | [Apply](https://imply.io/positions?gh_jid=7595374003) |
-| Yugabyte |  Software Engineer  | India | 2026-01-21 | [Apply](https://job-boards.greenhouse.io/yugabyte/jobs/4596483006) |
-| 🚀 Grammarly | Software Engineer, Data Engineering | San Francisco; Hybrid | 2026-01-20 | [Apply](https://job-boards.greenhouse.io/grammarly/jobs/6259939) |
-| 🚀 Grammarly | Software Engineer, Data Engineering | New York City; Hybrid | 2026-01-20 | [Apply](https://job-boards.greenhouse.io/grammarly/jobs/7336882) |
-| Sumo Logic | Software Engineer II - Core Platform  | United States | 2026-01-19 | [Apply](https://job-boards.greenhouse.io/sumologic/jobs/7485892) |
-| 🚀 Palantir | Forward Deployed Software Engineer - Autonomous Systems C2 | Palo Alto, CA | 2026-01-16 | [Apply](https://jobs.lever.co/palantir/c62264f5-5da8-40fe-9b44-f7f0f0012e11) |
-| 🚀 Palantir | Forward Deployed Software Engineer - Autonomous Systems C2 | Seattle, WA | 2026-01-16 | [Apply](https://jobs.lever.co/palantir/0edf7365-49f0-4263-818a-19409ec4f430) |
-| 🚀 PlanetScale | Software Engineer - Insights | San Francisco Bay Area or Remote | 2026-01-16 | [Apply](https://job-boards.greenhouse.io/planetscale/jobs/4107018009) |
-| ClickHouse | Core Software Engineer (C++) - Remote | Netherlands (remote) | 2026-01-16 | [Apply](https://job-boards.greenhouse.io/clickhouse/jobs/5755090004) |
-| ClickHouse | Core Software Engineer (C++) - Remote | United Kingdom (remote) | 2026-01-16 | [Apply](https://job-boards.greenhouse.io/clickhouse/jobs/5755091004) |
-| ClickHouse | Core Software Engineer (C++) - Remote | Germany (remote) | 2026-01-16 | [Apply](https://job-boards.greenhouse.io/clickhouse/jobs/5755092004) |
-| ClickHouse | Core Software Engineer (C++) - Remote | India (remote) | 2026-01-16 | [Apply](https://job-boards.greenhouse.io/clickhouse/jobs/5767816004) |
-| ClickHouse | Core Software Engineer (C++) - Remote | United States (remote) | 2026-01-16 | [Apply](https://job-boards.greenhouse.io/clickhouse/jobs/5755093004) |
-| Yugabyte | Software Engineer II | United States | 2026-01-15 | [Apply](https://job-boards.greenhouse.io/yugabyte/jobs/4586344006) |
-| 🔥 Lyft | Software Engineer, Frontend - Mapping Experiences | Toronto, Canada | 2026-01-14 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8367669002?gh_jid=8367669002) |
-| 🚀 Palantir | Software Engineer - Core Interfaces | Palo Alto, CA | 2026-01-13 | [Apply](https://jobs.lever.co/palantir/cf76738e-3030-42fa-92ac-a9446df956fc) |
-| 🚀 Twitch | Software Engineer I | Seattle, WA | 2026-01-13 | [Apply](https://job-boards.greenhouse.io/twitch/jobs/8360103002) |
-| 🚀 Twitch | Software Engineer I | San Francisco, CA | 2026-01-13 | [Apply](https://job-boards.greenhouse.io/twitch/jobs/8334351002) |
-| 🚀 Twitch | Software Engineer I - Ads Demand Enablement | San Francisco, CA | 2026-01-13 | [Apply](https://job-boards.greenhouse.io/twitch/jobs/8162197002) |
-| 🚀 Twitch | Software Engineer II, Android | San Francisco, CA | 2026-01-13 | [Apply](https://job-boards.greenhouse.io/twitch/jobs/8326458002) |
-| 🚀 Twitch | Software Engineer, ML Products | San Francisco, CA | 2026-01-13 | [Apply](https://job-boards.greenhouse.io/twitch/jobs/8183360002) |
-| 🚀 Palantir | Forward Deployed Software Engineer - US Government | Fayetteville, NC | 2026-01-12 | [Apply](https://jobs.lever.co/palantir/d83fac1c-353e-4b77-a586-3276b1090b6e) |
-| 🔥 Lyft | Software Engineer, Customer Care | Toronto, Canada | 2026-01-12 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8359671002?gh_jid=8359671002) |
-| Kitco Metals Inc. | Software Developer- AI Focus (Level 1)/Développeur Logiciel AI (Niveau 1) | Montréal, QC, CA | 1 day ago | [Apply](https://ca.indeed.com/viewjob?jk=3180925022f38600) |
-| Spin Master | Embedded Software Engineer (Contract) | Toronto, ON, CA | 6 days ago | [Apply](https://ca.indeed.com/viewjob?jk=6edb038b6c71b02e) |
-| Get Well Network | Software Engineer | KA, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=cdee5156f4f177e3) |
-| Capgemini | Associate Software Engineer | MH, IN | 2 days ago | [Apply](https://in.indeed.com/viewjob?jk=e95c036d4e55a5bf) |
-| Hewlett Packard Enterprise | HPE | Software Engineer - Layer 2 control plane engineer | KA, IN | 4 days ago | [Apply](https://in.indeed.com/viewjob?jk=5b2f64c878110dc0) |
-| AN Prakash CPMC Pvt Ltd | AI Software Engineer | KA, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=7b97f657b84884b6) |
-| CGI | Software Engineer | TS, IN | 2 days ago | [Apply](https://in.indeed.com/viewjob?jk=6b7baf7d6de9e37a) |
-| 🔥 Apple | SME - Equipment Design (Controls & Systems Engineer) | KA, IN | 3 days ago | [Apply](https://in.indeed.com/viewjob?jk=b9d038dd3d8f84c7) |
-| UKG | Software Engineer III- Eng | UP, IN | 2026-03-05 | [Apply](https://in.indeed.com/viewjob?jk=bf4ce69cf3f3086a) |
-| Roche | Software Engineer | MH, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=c8c395e4f2941b3b) |
-| Accenture | Custom Software Engineer | MH, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=41d31647d1fb3b1f) |
-| Accenture | Custom Software Engineer | KA, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=a342fa2e1825f633) |
-| Accenture | Custom Software Engineer | MH, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=1371592762b047ae) |
-| Accenture | Custom Software Engineer | KA, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=7abf1efe801465ca) |
-| Accenture | Custom Software Engineer | KA, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=31fb17b9bdf12beb) |
-| Accenture | Custom Software Engineer | KA, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=1d971f9bcb04ffb7) |
-| Accenture | Custom Software Engineer | MH, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=b47844344ec70d90) |
-| Accenture | Custom Software Engineer | MH, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=e1e93d9d34e50917) |
-| Accenture | Custom Software Engineer | MH, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=f5c780cb1cf0e8f7) |
-| Accenture | Custom Software Engineer | MH, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=bde40e4ff48c8480) |
-| Accenture | Custom Software Engineer | KA, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=3bccb37f0d50a120) |
-| Accenture | Custom Software Engineer | KA, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=9f6af5aaaf5747b0) |
-| Accenture | Custom Software Engineer | KA, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=39c25d285169d065) |
-| Accenture | Custom Software Engineer | MH, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=6c9edad30d67403a) |
-| Accenture | Custom Software Engineer | KA, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=2a627032788c2e65) |
-| Accenture | Custom Software Engineer | KA, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=05d00d806ad3cff2) |
-| Accenture | Custom Software Engineer | MH, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=664fae9c42721cf3) |
-| Accenture | Custom Software Engineer | MH, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=485a6c0a156c6863) |
-| Accenture | Custom Software Engineer | KA, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=9a0b8b6c2601e58f) |
-| Accenture | Custom Software Engineer | MH, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=81690c23804eaed6) |
-| Accenture | Custom Software Engineer | TS, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=de926d175b361cdb) |
-| Accenture | Custom Software Engineer | KA, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=7cae8da7d8e29a63) |
-| LyricFind | Software Developer | Toronto, ON, CA | 1 day ago | [Apply](https://ca.indeed.com/viewjob?jk=4885d38efeb22ec0) |
-| Delta-Q Technologies | Firmware/Embedded Software Engineer (15-Month Contract) | Vancouver, BC, CA | 1 day ago | [Apply](https://ca.indeed.com/viewjob?jk=e931c049cdfe24c0) |
-| 🔥 HP | Software Engineer 4 | KA, IN | 6 days ago | [Apply](https://in.indeed.com/viewjob?jk=0e5b609c9aa5a01c) |
-| Peraton | JUNIOR SOFTWARE DEVELOPER | Herndon, VA, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=651e433049f1888c) |
-| WEX Inc. | Junior Software Engineer | Remote, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=2dad01009f3aaace) |
-| Jack in the Box | Systems Engineer III | San Diego, CA, US | 2026-01-13 | [Apply](https://www.indeed.com/viewjob?jk=e24294be686a0902) |
-| Hologic | Embedded Software Engineer | Marlborough, MA, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=c535cf20aff11710) |
-| Hewlett Packard Enterprise | HPE | SW Engineering (Systems) - Software Engineer I -Embedded System | Sunnyvale, CA, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=c0e21a96049cb58f) |
-| Emerson | Embedded Software Engineer | Boulder, CO, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=2352a97f10ab57f2) |
-| 🔥 NVIDIA | Long-Horizon Agents Software Engineer — New College Grad 2026 | Santa Clara, CA, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=031c2298d26f574b) |
-| None | Embedded Software Engineer | Greenwood, IN, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=99349c056840939f) |
-| Scotiabank | Software Engineer Associate | Toronto, ON, CA | 3 days ago | [Apply](https://ca.indeed.com/viewjob?jk=b4c7b3c583edddd9) |
-| Scotiabank | Software Engineer Associate | Toronto, ON, CA | 3 days ago | [Apply](https://ca.indeed.com/viewjob?jk=8320a35c9e3ac741) |
-| Koho Financial | Software Engineer II, Data | CA | 3 days ago | [Apply](https://ca.indeed.com/viewjob?jk=c96c764a59aa6b4f) |
-| Jerry | Associate Software Engineer | Toronto, ON, CA | 3 days ago | [Apply](https://ca.indeed.com/viewjob?jk=5f354408d2b3873e) |
-| Gartner | Software Engineer (Salesforce Devops & Metadata API) | HR, IN | Today | [Apply](https://in.indeed.com/viewjob?jk=9f04e3f820d18895) |
-| JPMorganChase | Applied AI ML Associate | TS, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=fecb3e0337355269) |
-| BlackRock | Full Stack Engineer, Aladdin Engineering, Associate | HR, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=5cc863691c216579) |
-| CGI | SAP Concur Expenses & Travel / Software Engineer | KA, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=2905e3e382b9d40d) |
-| Wolters Kluwer | Enterprise Cloud Software Engineer (Cloud Operations, AI Engineering, Azure/AWS) | TN, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=d438b58a1eb1c3ee) |
-| Wolters Kluwer | Enterprise Cloud Software Engineer (Cloud Operations, AI Engineering, Azure/AWS) | MH, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=12d22d6df764928b) |
-| Wolters Kluwer | Enterprise Cloud Software Engineer (CloudOps Engineer, AI Engineering) | MH, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=35cbe5eb0daf418e) |
-| Wolters Kluwer | Enterprise Cloud Software Engineer (Cloud Operations, AI Engineering, Azure/AWS) | TN, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=00ff9654065215f7) |
-| London Health Sciences Centre | Temporary Software Developer - Data Integration | London, ON, CA | 5 days ago | [Apply](https://ca.indeed.com/viewjob?jk=2d3a23a35a0b2320) |
-| 🔥 Northrop Grumman | Systems Engineer - Level 3 or 4 🇺🇸 | Colorado Springs, CO, US | 2026-03-04 | [Apply](https://www.indeed.com/viewjob?jk=ce76b4536292b180) |
-| 🔥 Northrop Grumman | Modeling & Simulation Systems Engineer - Level 2 or 3 🇺🇸 | Colorado Springs, CO, US | 2026-03-04 | [Apply](https://www.indeed.com/viewjob?jk=810807b6dbaabffc) |
-| Amazon Web Services | Associate Cloud Application Developer 🇺🇸 | Arlington, VA, US | 2026-03-04 | [Apply](https://www.indeed.com/viewjob?jk=89036bb4e08d6597) |
-| Snap Inc. | Software Engineer, Lens Studio, Level 4 | Los Angeles, CA, US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=41c3d10d7791ab3e) |
-| Kansas City National Security Campus | Software Engineer | Kansas City, MO, US | 3 days ago | [Apply](https://www.indeed.com/viewjob?jk=359d9897df4061b9) |
-| Connor, Clark & Lunn Financial Group | Quantitative Equity Technology, Infrastructure Software Engineer | Vancouver, BC, CA | 3 days ago | [Apply](https://ca.indeed.com/viewjob?jk=aefa134fda82bda2) |
-| 🔥 Adobe | Computer Scientist - II (Frontend) | Noida | 1 day ago | [Apply](https://adobe.wd5.myworkdayjobs.com/job/Noida/Software-Development-Engineer-4_R165720) |
-| 🔥 PayPal | Software Engineer - Android | San Jose, California, United States of America | 1 day ago | [Apply](https://paypal.wd1.myworkdayjobs.com/job/San-Jose-California-United-States-of-America/Software-Engineer---Android_R0134717-1) |
-| 🔥 PayPal | Software Engineer - Full Stack | Bangalore, Karnataka, India | 1 day ago | [Apply](https://paypal.wd1.myworkdayjobs.com/job/Bangalore-Karnataka-India/Software-Engineer---Full-Stack_R0135007-1) |
-| 🔥 PayPal | Software Engineer - Java | San Jose, California, United States of America | 1 day ago | [Apply](https://paypal.wd1.myworkdayjobs.com/job/San-Jose-California-United-States-of-America/Software-Engineer---Java_R0135356-1) |
-| 🔥 PayPal | Software Engineer - Java | San Jose, California, United States of America | 1 day ago | [Apply](https://paypal.wd1.myworkdayjobs.com/job/San-Jose-California-United-States-of-America/Software-Engineer---Java_R0135357-1) |
-| 🔥 PayPal | Software Engineer - Python | San Jose, California, United States of America | 1 day ago | [Apply](https://paypal.wd1.myworkdayjobs.com/job/San-Jose-California-United-States-of-America/Software-Engineer---Python_R0134423-1) |
-| 🔥 PayPal | Software Engineer - Java | San Jose, California, United States of America | 1 day ago | [Apply](https://paypal.wd1.myworkdayjobs.com/job/San-Jose-California-United-States-of-America/Software-Engineer---Java_R0133240-1) |
-| 🔥 PayPal | Software Engineer, Backend Java | San Jose, California, United States of America | 1 day ago | [Apply](https://paypal.wd1.myworkdayjobs.com/job/San-Jose-California-United-States-of-America/Software-Engineer--Backend-Java_R0134880-1) |
-| 🔥 PayPal | Software Engineer, iOS | San Jose, California, United States of America | 1 day ago | [Apply](https://paypal.wd1.myworkdayjobs.com/job/San-Jose-California-United-States-of-America/Software-Engineer--iOS_R0134718-1) |
-| 🔥 PayPal | Software Engineer | San Jose, California, United States of America | 1 day ago | [Apply](https://paypal.wd1.myworkdayjobs.com/job/San-Jose-California-United-States-of-America/Software-Engineer_R0134515-1) |
-| 🔥 Mastercard | Software Engineer II (Java) | Vancouver, Canada | 1 day ago | [Apply](https://mastercard.wd1.myworkdayjobs.com/job/Vancouver-Canada/Software-Engineer-II--Java-_R-271844-1) |
-| 🔥 Mastercard | Software Engineer II | O'Fallon, Missouri | 2 days ago | [Apply](https://mastercard.wd1.myworkdayjobs.com/job/OFallon-Missouri/Software-Engineer-II_R-272392) |
-| 🔥 Mastercard | Software Engineer II | Pune, India | 2 days ago | [Apply](https://mastercard.wd1.myworkdayjobs.com/job/Pune-India/Software-Engineer-II_R-266063-1) |
-| 🔥 NVIDIA | Long-Horizon Agents Software Engineer — New College Grad 2026 | US, CA, Santa Clara | Today | [Apply](https://nvidia.wd5.myworkdayjobs.com/job/US-CA-Santa-Clara/Long-Horizon-Agents-Software-Engineer---New-College-Grad-2026_JR2014184) |
-| 🔥 NVIDIA | Frontend Web Applications Software Engineer | US, CA, Santa Clara | Today | [Apply](https://nvidia.wd5.myworkdayjobs.com/job/US-CA-Santa-Clara/Frontend-Web-Applications-Software-Engineer_JR2010044-1) |
-| Dell | Job Posting Title Software Engineer Platform Systems Engineer (Hopkinton, MA) | Hopkinton, Massachusetts, United States | 2 days ago | [Apply](https://dell.wd1.myworkdayjobs.com/job/Hopkinton-Massachusetts-United-States/Job-Posting-Title-Software-Engineer-Platform-Systems-Engineer--Hopkinton--MA-_R285888-1) |
-| 🔥 HP | Software Engineer 4 | Bengaluru, Karnataka, India | 5 days ago | [Apply](https://hp.wd5.myworkdayjobs.com/job/Bengaluru-Karnataka-India/Data-Software-Engineer_3150228-1) |
-| Workday | Software Engineer III | USA, CO, Boulder | 2 days ago | [Apply](https://workday.wd5.myworkdayjobs.com/job/USA-CO-Boulder/Software-Engineer-III_JR-0104575) |
-| 🔥 Autodesk | Software Engineer | Bengaluru, IND | 1 day ago | [Apply](https://autodesk.wd1.myworkdayjobs.com/job/Bengaluru-IND/Software-Engineer_26WD94921-1) |
-| 🔥 Autodesk | Software Engineer (Typescript/Python) | Pune, IND | 5 days ago | [Apply](https://autodesk.wd1.myworkdayjobs.com/job/Pune-IND/Software-Engineer_26WD94552-1) |
-| Medtronic | Quality Software Engineer II | North Haven, Connecticut, United States of America | 1 day ago | [Apply](https://medtronic.wd1.myworkdayjobs.com/job/North-Haven-Connecticut-United-States-of-America/Quality-Software-Engineer-II_R55056-1) |
-| Walmart | (IND) Software Engineer III | IN KA BANGALORE Home Office PTPP2 | Today | [Apply](https://walmart.wd5.myworkdayjobs.com/job/IN-KA-BANGALORE-Home-Office-PTPP2/XMLNAME--IND--Software-Engineer-III_R-2427186) |
-| Walmart | Software Engineer III | (USA) Crossman Service Building CA SUNNYVALE Home Office | 1 day ago | [Apply](https://walmart.wd5.myworkdayjobs.com/job/USA-Crossman-Service-Building-CA-SUNNYVALE-Home-Office/Software-Engineer-III_R-2435899) |
-| Walmart | SOFTWARE ENGINEER III | IN KA BANGALORE Home Office Building 11 | 5 days ago | [Apply](https://walmart.wd5.myworkdayjobs.com/job/IN-KA-BANGALORE-Home-Office-Building-11/SOFTWARE-ENGINEER-III_R-2419990) |
-| Walmart | SOFTWARE ENGINEER III | IN KA BANGALORE Home Office Building 11 | 2026-02-10 | [Apply](https://walmart.wd5.myworkdayjobs.com/job/IN-KA-BANGALORE-Home-Office-Building-11/SOFTWARE-ENGINEER-III_R-2363934) |
-| Walmart | SOFTWARE ENGINEER III, INFORMATION SECURITY | IN KA BANGALORE Home Office Building 11 | 2026-02-10 | [Apply](https://walmart.wd5.myworkdayjobs.com/job/IN-KA-BANGALORE-Home-Office-Building-11/SOFTWARE-ENGINEER-III--INFORMATION-SECURITY_R-2372696) |
-| Walmart | Software Engineer - Android | Reston, VA | 2026-02-10 | [Apply](https://walmart.wd5.myworkdayjobs.com/job/Reston-VA/Software-Engineer---Android_R-1715700-1) |
-| Walmart | Software Engineer - Android | Sunnyvale, CA | 2026-02-10 | [Apply](https://walmart.wd5.myworkdayjobs.com/job/Sunnyvale-CA/Software-Engineer---Android_R-1694188-1) |
-| Walmart | Software Engineer - Android | Bentonville, AR | 2026-02-10 | [Apply](https://walmart.wd5.myworkdayjobs.com/job/Bentonville-AR/Software-Engineer---Android_R-1717052-1) |
-| Walmart | Software Engineer - iOS | Bentonville, AR | 2026-02-10 | [Apply](https://walmart.wd5.myworkdayjobs.com/job/Bentonville-AR/Software-Engineer---iOS_R-1717051-1) |
-| 🔥 Northrop Grumman | Threat Mod & Sim - Systems Engineer - Level 2 or 3 | United States-Colorado-Schriever AFB | Today | [Apply](https://ngc.wd1.myworkdayjobs.com/job/United-States-Colorado-Schriever-AFB/Threat-Mod---Sim---Systems-Engineer---Level-2-or-3_R10225724) |
-| 🔥 Northrop Grumman | Systems Engineer – Electromagnetic Effects and Nuclear Hardness Engineer | United States-California-Palmdale | Today | [Apply](https://ngc.wd1.myworkdayjobs.com/job/United-States-California-Palmdale/Systems-Engineer---Electromagnetic-Effects-and-Nuclear-Hardness-Engineer_R10225528) |
-| 🔥 Northrop Grumman | Systems Engineer - Level 5 | United States-Colorado-Aurora | Today | [Apply](https://ngc.wd1.myworkdayjobs.com/job/United-States-Colorado-Aurora/Systems-Engineer---Level-5_R10225598) |
-| 🔥 Northrop Grumman | Cyber Systems Engineer (Level 2 or 3) | United States-Virginia-Dulles | 1 day ago | [Apply](https://ngc.wd1.myworkdayjobs.com/job/United-States-Virginia-Dulles/Cyber-Systems-Engineer--Level-2-or-3-_R10225521) |
-| 🔥 Northrop Grumman | Weapons C++ Embedded Software Engineer Level 4 (AHT) | United States-California-Northridge | 1 day ago | [Apply](https://ngc.wd1.myworkdayjobs.com/job/United-States-California-Northridge/Weapons-C---Embedded-Software-Engineer-Level-4--AHT-_R10225516) |
-| 🔥 Northrop Grumman | 2026 Associate Cyber Systems Engineer / 2026 Cyber Systems Engineer - Roy UT | United States-Utah-Roy | 1 day ago | [Apply](https://ngc.wd1.myworkdayjobs.com/job/United-States-Utah-Roy/XMLNAME-2026-Associate-Cyber-Systems-Engineer---2026-Cyber-Systems-Engineer---Roy-UT_R10225475) |
-| 🔥 Northrop Grumman | Software Engineer: Automation - Level 2 or 3 (Chandler) | United States-Arizona-Chandler | 1 day ago | [Apply](https://ngc.wd1.myworkdayjobs.com/job/United-States-Arizona-Chandler/Software-Engineer--Automation---Level-2-or-3--Chandler-_R10223203) |
-| 🔥 Boeing | Software Engineer | USA - Hazelwood, MO | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---Hazelwood-MO/Software-Engineer_JR2026499523) |
-| 🔥 Boeing | 787 Cabin Systems Engineer, Associate - Charleston, SC | USA - North Charleston, SC | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---North-Charleston-SC/XMLNAME-787-Cabin-Systems-Engineer--Associate---Charleston--SC_JR2026499336-2) |
-| 🔥 Boeing | Experienced Systems Engineer - Health Management | USA - Hazelwood, MO | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---Hazelwood-MO/Experienced-Systems-Engineer_JR2025456769) |
-| 🔥 Boeing | F-22 Associate System Integration Engineer | USA - Berkeley, MO | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---Berkeley-MO/F-22-Associate-System-Integration-Engineer_JR2026497316-1) |
-| 🔥 Boeing | Application Developer (Scientific Applications) -  (Entry-Level, Associate, or Mid-Level) | USA - Everett, WA | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---Everett-WA/Application-Developer--Scientific-Applications------Entry-Level--Associate--or-Mid-Level-_JR2025488280) |
-| 🔥 Boeing | Systems Software Engineer | United States - Remote | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/United-States---Remote/Systems-Software-Engineer_JR2026496174-2) |
-| 🔥 Boeing | Entry-Level F-22 Software Engineer - Developer | USA - Berkeley, MO | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---Berkeley-MO/Entry-Level-F-22-Software-Engineer---Developer_JR2025474697-1) |
-| 🔥 Boeing | Spacecraft Systems Engineer (Experienced) - Millennium Space Systems | USA - El Segundo, CA | 1 day ago | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---El-Segundo-CA/Spacecraft-Systems-Engineer--Experienced----Millennium-Space-Systems_JR2026499500-2) |
+| Mixpanel | Software Engineer, AI Product Insights | San Francisco, US (Hybrid) | Today | [Apply](https://job-boards.greenhouse.io/mixpanel/jobs/7941930) |
+| Mixpanel | Software Engineer, DevInfra | San Francisco, US (Remote) | Today | [Apply](https://job-boards.greenhouse.io/mixpanel/jobs/7941929) |
+| xAI | Exceptional Software Engineer | Austin, TX; New York, NY; Palo Alto, CA; Seattle, WA | Today | [Apply](https://job-boards.greenhouse.io/xai/jobs/4956028007) |
+| xAI | IT Systems Engineer | Palo Alto, CA | Today | [Apply](https://job-boards.greenhouse.io/xai/jobs/4871633007) |
+| xAI | Software Engineer, Ads Product | Palo Alto, CA | Today | [Apply](https://job-boards.greenhouse.io/xai/jobs/5152408007) |
+| xAI | Software Engineer - Data | Palo Alto, CA | Today | [Apply](https://job-boards.greenhouse.io/xai/jobs/5124616007) |
+| xAI | Software Engineer - Kernels/CUDA (C++) | Palo Alto, CA; Seattle, WA | Today | [Apply](https://job-boards.greenhouse.io/xai/jobs/5052040007) |
+| xAI | Software Engineer - Network (C++) | Palo Alto, CA; Seattle, WA | Today | [Apply](https://job-boards.greenhouse.io/xai/jobs/5179367007) |
+| xAI | Software Engineer - Platform Security | Palo Alto, CA | Today | [Apply](https://job-boards.greenhouse.io/xai/jobs/4835611007) |
+| xAI | Software Engineer - Training/Inference (C++) | Palo Alto, CA | Today | [Apply](https://job-boards.greenhouse.io/xai/jobs/4533894007) |
+
+**[→ View all 858 Software Engineering roles on the live board](https://jobs.riteshrana.engineer/)**
 
 ## 🎨 Frontend Engineering New Grad Roles
 
@@ -655,8 +103,8 @@
 | Company | Role | Location | Posted | Apply |
 |---------|------|----------|--------|-------|
 | Anduril Industries | Frontend Software Engineer | Costa Mesa, California, United States | Today | [Apply](https://boards.greenhouse.io/andurilindustries/jobs/5147775007?gh_jid=5147775007) |
-| Anduril Industries | Mission Software Engineer, Air Vehicle Autonomy, Frontend | Costa Mesa, California, United States | Today | [Apply](https://boards.greenhouse.io/andurilindustries/jobs/4673956007?gh_jid=4673956007) |
 | Anduril Industries | Mission Software Engineer, Air Vehicle Autonomy, Frontend | Seattle, Washington, United States | Today | [Apply](https://boards.greenhouse.io/andurilindustries/jobs/4674088007?gh_jid=4674088007) |
+| Anduril Industries | Mission Software Engineer, Air Vehicle Autonomy, Frontend | Costa Mesa, California, United States | Today | [Apply](https://boards.greenhouse.io/andurilindustries/jobs/4673956007?gh_jid=4673956007) |
 | 🚀 Twilio | Frontend Software Engineer | Remote - United Kingdom | Today | [Apply](https://job-boards.greenhouse.io/twilio/jobs/7946608) |
 | Focus Camera | Junior Full Stack Web Developer | Brooklyn, NY, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=758d36fedb1d720f) |
 | 🚀 Glean | Software Engineer, Frontend | Mountain View, CA | 2026-07-06 | [Apply](https://job-boards.greenhouse.io/gleanwork/jobs/4006733005) |
@@ -680,28 +128,8 @@
 | 🔥 NVIDIA | Backend Compiler Engineer - New College Grad 2026 | Santa Clara, CA, US | 2 days ago | [Apply](https://www.indeed.com/viewjob?jk=ce865a2b9ec813b7) |
 | 🔥 NVIDIA | Backend Compiler Engineer - New College Grad 2026 | US, CA, Santa Clara | 2 days ago | [Apply](https://nvidia.wd5.myworkdayjobs.com/job/US-CA-Santa-Clara/Backend-Compiler-Engineer---New-College-Grad-2026_JR2021242) |
 | 🚀 Affirm | Software Engineer II, Backend (Test Infra) | Remote Canada | 5 days ago | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7727322003) |
-| 🚀 Affirm | Software Engineer II, Backend (Test Infra) | Remote US | 5 days ago | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7727320003) |
-| 🚀 Robinhood | Software Engineer, Backend | Menlo Park, CA | 5 days ago | [Apply](https://boards.greenhouse.io/robinhood/jobs/7263592?t=gh_src=&gh_jid=7263592) |
-| 🚀 Vercel | Software Engineer, Backend | Remote - United States | 2026-07-07 | [Apply](https://job-boards.greenhouse.io/vercel/jobs/5430088004) |
-| AppLovin | Backend Engineer II | Palo Alto, CA | 2026-07-06 | [Apply](https://boards.greenhouse.io/applovin/jobs/4375888006?gh_jid=4375888006) |
-| AppLovin | Backend Engineer, New Grad | Palo Alto, CA | 2026-07-06 | [Apply](https://boards.greenhouse.io/applovin/jobs/4451556006?gh_jid=4451556006) |
-| 🚀 Affirm | Software Engineer II, Backend (Reliability Platform) | Remote Canada | 2026-06-26 | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7764836003) |
-| 🚀 Affirm | Software Engineer II, Backend (Reliability Platform) | Remote US | 2026-06-26 | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7764834003) |
-| 🚀 Brex | Software Engineer II, Backend | Vancouver, British Columbia, Canada | 2026-06-26 | [Apply](https://www.brex.com/careers/8603327002?gh_jid=8603327002) |
-| 🚀 Affirm | Software Engineer II, Back-end (Card Mgmt & Transaction Processing) | Remote Canada | 2026-06-24 | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7777094003) |
-| 🚀 Affirm | Software Engineer II, Back-end (Card Mgmt & Transaction Processing) | Remote US | 2026-06-24 | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7766277003) |
-| 🚀 Airtable | Software Engineer, Product Backend (8+ YOE) | San Francisco, CA; New York, NY | 2026-06-23 | [Apply](https://job-boards.greenhouse.io/airtable/jobs/8397618002) |
-| 🚀 Affirm | Software Engineer II, Backend (Capital Orchestration) | Remote US | 2026-06-18 | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7749755003) |
-| 🚀 Affirm | Software Engineer II, Backend (PMI Integrations) | Remote Canada | 2026-06-18 | [Apply](https://job-boards.greenhouse.io/affirm/jobs/7590373003) |
-| 🚀 Waymo | Software Engineer Backend - Simulation | Mountain View | 2026-06-16 | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7307289) |
-| 🚀 Brex | Software Engineer II, Backend | New York, New York, United States | 2026-06-12 | [Apply](https://www.brex.com/careers/8536424002?gh_jid=8536424002) |
-| 🚀 Pinterest | Software Engineer II, Backend | San Francisco, CA, US; Seattle, WA, US | 2026-06-12 | [Apply](https://www.pinterestcareers.com/jobs/?gh_jid=4813946) |
-| Cockroach Labs | Software Engineer (Backend), GTM Tooling | New York, NY | 2026-06-10 | [Apply](https://www.cockroachlabs.com/careers/job/?gh_jid=7874104) |
-| 🚀 Brex | Software Engineer II, Backend | San Francisco, California, United States | 2026-06-10 | [Apply](https://www.brex.com/careers/8459783002?gh_jid=8459783002) |
-| 🚀 Pinterest | Software Engineer I, Backend | Seattle, WA, US; San Francisco, CA, US | 2026-06-09 | [Apply](https://www.pinterestcareers.com/jobs/?gh_jid=6816337) |
-| 🚀 Pinterest | Software Engineer II, Backend, tvScientific | San Francisco, CA, US; Remote, US | 2026-06-04 | [Apply](https://www.pinterestcareers.com/jobs/?gh_jid=7782552) |
-| 🚀 Pinterest | Software Engineer II, Backend | Toronto, ON, CA | 2026-06-04 | [Apply](https://www.pinterestcareers.com/jobs/?gh_jid=5132899) |
-| 🚀 Glean | Software Engineer, Backend | Bangalore, India | 2026-05-27 | [Apply](https://job-boards.greenhouse.io/gleanwork/jobs/4006731005) |
+
+**[→ View all 32 Backend Engineering roles on the live board](https://jobs.riteshrana.engineer/)**
 
 ## 📲 Mobile Engineering New Grad Roles
 
@@ -710,7 +138,6 @@
 | Company | Role | Location | Posted | Apply |
 |---------|------|----------|--------|-------|
 | Anduril Industries | Software Engineer - Mobile, Android | Costa Mesa, California, United States | Today | [Apply](https://boards.greenhouse.io/andurilindustries/jobs/5163532007?gh_jid=5163532007) |
-| Booz Allen Hamilton | Android CNO Software Developer | Annapolis Junction, MD | 1 day ago | [Apply](https://bah.wd1.myworkdayjobs.com/job/Annapolis-Junction-MD/Android-CNO-Software-Developer_R0237796) |
 | 🚀 Duolingo | Software Engineer II, Android | Pittsburgh, PA | 5 days ago | [Apply](https://careers.duolingo.com/jobs/8628658002?gh_jid=8628658002) |
 | 🚀 Duolingo | Software Engineer II, Android | New York, NY | 5 days ago | [Apply](https://careers.duolingo.com/jobs/8628670002?gh_jid=8628670002) |
 | 🚀 Chime | Mobile Software Engineer, Lending | San Francisco, CA, USA | 5 days ago | [Apply](https://boards.greenhouse.io/chime/jobs/8535338002?gh_jid=8535338002) |
@@ -731,22 +158,14 @@
 | xAI | Infrastructure Security Engineer | Austin, TX; New York, NY; Palo Alto, CA; Washington, D.C. | Today | [Apply](https://job-boards.greenhouse.io/xai/jobs/5090998007) |
 | xAI | Security Engineer - Azure Government | Palo Alto, CA; Washington, D.C. | Today | [Apply](https://job-boards.greenhouse.io/xai/jobs/5050657007) |
 | xAI | Security Engineer - Governance Risk Compliance | New York, NY; Palo Alto, CA; Washington, D.C. | Today | [Apply](https://job-boards.greenhouse.io/xai/jobs/5007261007) |
+| 🚀 SpaceX | Embedded Security Engineer (Starlink) | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8577410002?gh_jid=8577410002) |
 | 🚀 SpaceX | Embedded Security Engineer (Starlink) | Bastrop, TX | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8624836002?gh_jid=8624836002) |
 | 🚀 SpaceX | Embedded Security Engineer (Starlink) | Redmond, WA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8543670002?gh_jid=8543670002) |
-| 🚀 SpaceX | Embedded Security Engineer (Starlink) | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8577410002?gh_jid=8577410002) |
-| 🚀 SpaceX | Product Security Engineer (Starlink) | Redmond, WA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8543671002?gh_jid=8543671002) |
-| 🚀 SpaceX | Product Security Engineer (Starlink) | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8577411002?gh_jid=8577411002) |
 | 🚀 SpaceX | Product Security Engineer (Starlink) | Bastrop, TX | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8624835002?gh_jid=8624835002) |
-| 🚀 SpaceX | Product Security Engineer (Starshield) | Washington, DC | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8492058002?gh_jid=8492058002) |
-| 🚀 SpaceX | Security Engineer | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8567571002?gh_jid=8567571002) |
-| 🚀 SpaceX | Security Engineer | Cape Canaveral, FL | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8567522002?gh_jid=8567522002) |
-| 🚀 SpaceX | Security Engineer (Blue Team) | Redmond, WA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8611050002?gh_jid=8611050002) |
-| 🚀 SpaceX | Security Engineer (Blue Team) | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8611223002?gh_jid=8611223002) |
-| 🚀 SpaceX | Security Engineer (Embedded & Networking) | Cape Canaveral, FL | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8593385002?gh_jid=8593385002) |
-| 🚀 SpaceX | Security Engineer (Embedded & Networking) | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8593384002?gh_jid=8593384002) |
-| 🚀 SpaceX | Security Engineer (Embedded OT) | Cape Canaveral, FL | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8593389002?gh_jid=8593389002) |
-| 🚀 SpaceX | Security Engineer (Embedded OT) | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8593388002?gh_jid=8593388002) |
-| 🚀 StubHub | Software Engineer II - Product Security | Los Angeles, California, United States | Today | [Apply](https://job-boards.eu.greenhouse.io/stubhubinc/jobs/4903899101) |
+| 🚀 SpaceX | Product Security Engineer (Starlink) | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8577411002?gh_jid=8577411002) |
+| 🚀 SpaceX | Product Security Engineer (Starlink) | Redmond, WA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8543671002?gh_jid=8543671002) |
+
+**[→ View all 85 Security Engineering roles on the live board](https://jobs.riteshrana.engineer/)**
 
 ## 🤖 Data Science & ML New Grad Roles
 
@@ -754,109 +173,18 @@
 
 | Company | Role | Location | Posted | Apply |
 |---------|------|----------|--------|-------|
-| 🚀 Waymo | Applied Research Scientist, 3D Object Detection  (PhD New Grad) | Mountain View, CA USA;  San Francisco, CA USA; | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7467839) |
-| 🚀 Waymo | Applied Research Scientist, Perception LLM/VLM (PhD, New Grad) | Mountain View, CA USA;  San Francisco, CA USA; | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7488508) |
-| 🚀 Waymo | Data Scientist  | Mountain View, California, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=6608598) |
-| 🚀 Waymo | Machine Learning Engineer | Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7455853) |
-| 🚀 Waymo | Machine Learning Engineer, 3D Object Detection  (PhD New Grad) | Mountain View, CA USA;  San Francisco, CA USA; | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7539786) |
-| 🚀 Waymo | Machine Learning Engineer, ADV Systems | Mountain View, California, United States; San Francisco, California, United States | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7446320) |
-| 🚀 Waymo | Machine Learning Engineer, Data & Systems  | Mountain View, California, United States; San Francisco, California, United States | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7446301) |
-| 🚀 Waymo | Machine Learning Engineer - Mapping | Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7429791) |
-| 🚀 Waymo | Machine Learning Engineer - Mapping | Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7429811) |
-| 🚀 Waymo | Machine Learning Engineer, Mapping | Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7090492) |
-| 🚀 Waymo | Machine Learning Engineer, ML Flywheel | Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7426598) |
-| 🚀 Waymo | Machine Learning Engineer, ML Resources | Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7424806) |
-| 🚀 Waymo | Machine Learning Engineer, Model Optimization | Mountain View, California, United States; San Francisco, California, United States | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7446322) |
-| 🚀 Waymo | Machine Learning Engineer, Perception Modeling | Mountain View, CA, USA; San Francisco, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7446279) |
-| 🚀 Waymo | Machine Learning Engineer, Prediction & Planning | Mountain View, CA, USA; San Francisco, CA, USA; New York City, NY, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=6506689) |
-| 🚀 Waymo | Machine Learning Engineer, Runtime & Optimization | Mountain View, California, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=6506008) |
-| 🚀 Waymo | Machine Learning Engineer, Simulation Realism | Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=6499165) |
-| 🚀 Waymo | Machine Learning Engineer, Simulation Realism  | Mountain View, CA, USA | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=6688617) |
-| 🚀 Waymo | ML Engineer, Foundation Model Evaluation | Mountain View, CA, USA; Remote US | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7536948) |
-| 🚀 Waymo | ML Engineer, Foundation Model Infrastructure | Mountain View, CA, USA; Remote US | Today | [Apply](https://careers.withwaymo.com/jobs?gh_jid=7536801) |
-| Scopely | Data Scientist - Marketing & Product | US - San Francisco, United States | Today | [Apply](https://job-boards.greenhouse.io/scopely/jobs/5123723008) |
-| 🚀 Robinhood | Data Scientist, Product | New York, NY | 1 day ago | [Apply](https://boards.greenhouse.io/robinhood/jobs/7324983?t=gh_src=&gh_jid=7324983) |
-| 🔥 Lyft | Data Scientist - Decisions, Mapping | Toronto, Canada | 1 day ago | [Apply](https://app.careerpuck.com/job-board/lyft/job/8448179002?gh_jid=8448179002) |
-| 🔥 Stripe | Data Scientist | Toronto | 5 days ago | [Apply](https://stripe.com/jobs/search?gh_jid=7357460) |
-| 🔥 Stripe | Machine Learning Engineer, Payments ML Accelerator | Seattle; San Francisco; New York City | 5 days ago | [Apply](https://stripe.com/jobs/search?gh_jid=7079044) |
-| 🔥 Stripe | Machine Learning Engineer, Stripe Assistant  | Seattle; San Francisco; New York City; Remote | 5 days ago | [Apply](https://stripe.com/jobs/search?gh_jid=7629052) |
-| 🔥 Stripe | PhD Machine Learning Engineer, New Grad | San Francisco, New York City, Seattle | 5 days ago | [Apply](https://stripe.com/jobs/search?gh_jid=7216668) |
-| Opendoor | Data Scientist | Seattle, Washington, United States | 5 days ago | [Apply](https://www.opendoor.com/careers/open-positions?gh_jid=4659693006) |
-| 🚀 Coinbase | Data Scientist II - Product Analytics | Remote - UK | 6 days ago | [Apply](https://www.coinbase.com/careers/positions/7644362?gh_jid=7644362) |
-| 🚀 Coinbase | Data Scientist II - Platform | Remote - USA | 6 days ago | [Apply](https://www.coinbase.com/careers/positions/6679661?gh_jid=6679661) |
-| 🚀 Pinterest | Machine Learning Engineer, tvScientific | San Francisco, CA, US; Remote, US | 2026-03-04 | [Apply](https://www.pinterestcareers.com/jobs/?gh_jid=7642265) |
-| 🚀 Pinterest | Data Scientist II, Growth Marketing | San Francisco, CA, US; Remote, US | 2026-03-04 | [Apply](https://www.pinterestcareers.com/jobs/?gh_jid=6483005) |
-| 🚀 Dropbox | Machine Learning Engineer, Dash | Remote - Germany | 2026-03-04 | [Apply](https://jobs.dropbox.com/listing/7621678?gh_jid=7621678) |
-| 🚀 Reddit | Data Scientist, Ads | Remote - United States | 2026-03-04 | [Apply](https://job-boards.greenhouse.io/reddit/jobs/6580815) |
-| 🚀 Reddit | Data Scientist, Ads | Remote - Ontario, Canada | 2026-03-04 | [Apply](https://job-boards.greenhouse.io/reddit/jobs/7607124) |
-| 🚀 SoFi | Risk Data AI/ML Engineer | Frisco, TX  | 2026-03-03 | [Apply](https://sofi.com/careers/job/7644234003?gh_jid=7644234003) |
-| Abnormal Security | Machine Learning Engineer II | Remote - USA | 2026-03-03 | [Apply](https://abnormal.ai/careers/jobs/7612697003?gh_jid=7612697003) |
-| Opendoor | Data Scientist | Office - Washington-Seattle | 2026-03-02 | [Apply](https://www.opendoor.com/careers/open-positions?gh_jid=4615429006) |
-| Opendoor | Data Scientist | Office - Washington-Seattle | 2026-03-02 | [Apply](https://www.opendoor.com/careers/open-positions?gh_jid=4613844006) |
-| Opendoor | Data Scientist | Toronto | 2026-03-02 | [Apply](https://www.opendoor.com/careers/open-positions?gh_jid=4613845006) |
-| Opendoor | Data Scientist | Seattle, Washington, United States | 2026-02-26 | [Apply](https://www.opendoor.com/careers/open-positions?gh_jid=4653303006) |
-| 🚀 Grammarly | Machine Learning Engineer, Agents | San Francisco; Hybrid | 2026-02-26 | [Apply](https://job-boards.greenhouse.io/grammarly/jobs/6392339) |
-| 🚀 Pinterest | Machine Learning Engineer, Core Engineering | San Francisco, CA, US; Palo Alto, CA, US; Seattle, WA, US; Remote, US | 2026-02-25 | [Apply](https://www.pinterestcareers.com/jobs/?gh_jid=6121450) |
-| 🚀 Pinterest | Machine Learning Engineer II | Toronto, ON, CA | 2026-02-25 | [Apply](https://www.pinterestcareers.com/jobs/?gh_jid=7473497) |
-| 🚀 Pinterest | Machine Learning Engineer, Monetization Engineering | San Francisco, CA, US; Palo Alto, CA, US; Seattle, WA, US | 2026-02-25 | [Apply](https://www.pinterestcareers.com/jobs/?gh_jid=6121543) |
-| 🚀 SoFi | Marketing Data Scientist, Optimization | San Francisco, CA | 2026-02-23 | [Apply](https://sofi.com/careers/job/7615953003?gh_jid=7615953003) |
-| 🚀 SoFi | Marketing Data Scientist, Reporting | San Francisco, CA | 2026-02-23 | [Apply](https://sofi.com/careers/job/7615949003?gh_jid=7615949003) |
-| 🔥 Lyft | Machine Learning Engineer, Recommendations | Toronto, Canada | 2026-02-20 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8378390002?gh_jid=8378390002) |
-| 🚀 Roblox | [2026] Data Scientist, Foundation AI - PhD Early Career | San Mateo, CA, United States | 2026-02-19 | [Apply](https://careers.roblox.com/jobs/7577436?gh_jid=7577436) |
-| 🚀 Roblox | Data Scientist - Analytical Data Product (Temporary) | San Mateo, CA, United States | 2026-02-19 | [Apply](https://careers.roblox.com/jobs/7276845?gh_jid=7276845) |
-| 🚀 Roblox | Data Scientist, People Analytics | San Mateo, CA, United States | 2026-02-19 | [Apply](https://careers.roblox.com/jobs/7125944?gh_jid=7125944) |
-| 🚀 Roblox | Data Scientist, People Science | San Mateo, CA, United States | 2026-02-19 | [Apply](https://careers.roblox.com/jobs/7346551?gh_jid=7346551) |
-| Spotify | Machine Learning Engineer | New York, NY | 2026-02-19 | [Apply](https://jobs.lever.co/spotify/e200d025-4cff-4eb8-afa4-6680e31c43a2) |
-| 🔥 Lyft | Data Scientist, Decisions - Central Market Management | San Francisco, CA | 2026-02-17 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8376875002?gh_jid=8376875002) |
-| 🔥 Lyft | Data Scientist, Decisions - Central Market Management | New York, NY | 2026-02-17 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8378473002?gh_jid=8378473002) |
-| Spotify | Data Scientist - Advertising | New York, NY | 2026-02-13 | [Apply](https://jobs.lever.co/spotify/533fbd4f-4934-4818-b519-3b9652cd3811) |
-| 🔥 Lyft | Data Scientist, Supply and Operations Technology, Lyft Urban Solutions | New York, NY | 2026-02-11 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8402782002?gh_jid=8402782002) |
-| Greenhouse | Machine Learning Engineer | Anywhere in the United States | 2026-02-11 | [Apply](https://job-boards.greenhouse.io/greenhouse/jobs/7477093?gh_jid=7477093) |
-| Greenhouse | Machine Learning Engineer | Ontario or British Columbia | 2026-02-11 | [Apply](https://job-boards.greenhouse.io/greenhouse/jobs/7589729?gh_jid=7589729) |
-| 🚀 Reddit | Machine Learning Engineer, Search and Answers | Remote - United States | 2026-02-09 | [Apply](https://job-boards.greenhouse.io/reddit/jobs/6534982) |
-| 🚀 Instacart | Machine Learning Engineer II, Economics | United States - Remote | 2026-02-08 | [Apply](https://instacart.careers/job/?gh_jid=7565189) |
-| Oscar Health | Data Scientist II | Tempe, Arizona, United States | 2026-02-06 | [Apply](http://www.hioscar.com/careers/7594416?gh_jid=7594416) |
-| Oscar Health | Data Scientist II | Los Angeles, California, United States | 2026-02-06 | [Apply](http://www.hioscar.com/careers/7594414?gh_jid=7594414) |
-| Oscar Health | Data Scientist II | New York, New York, United States | 2026-02-06 | [Apply](http://www.hioscar.com/careers/7592301?gh_jid=7592301) |
-| Oscar Health | Data Scientist I | Tempe, Arizona, United States | 2026-02-06 | [Apply](http://www.hioscar.com/careers/7594392?gh_jid=7594392) |
-| Oscar Health | Data Scientist I | Los Angeles, California, United States | 2026-02-06 | [Apply](http://www.hioscar.com/careers/7594388?gh_jid=7594388) |
-| Oscar Health | Data Scientist I | New York, New York, United States | 2026-02-06 | [Apply](http://www.hioscar.com/careers/7592274?gh_jid=7592274) |
-| Spotify | Data Scientist - Music Mission | New York, NY | 2026-02-05 | [Apply](https://jobs.lever.co/spotify/c4a86464-a90d-4e16-9890-1f79355a41ac) |
-| 🔥 Lyft | Data Scientist, Algorithms | Seattle, WA | 2026-02-05 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8401123002?gh_jid=8401123002) |
-| 🔥 Lyft | Data Scientist, Algorithms | San Francisco, CA | 2026-02-05 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8401222002?gh_jid=8401222002) |
-| 🔥 Lyft | Data Scientist, Algorithms, ML - Fulfillment | Toronto, Canada | 2026-02-04 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8404974002?gh_jid=8404974002) |
-| 🔥 Lyft | Data Scientist, Algorithms, Optimization - Fulfillment | Seattle, WA | 2026-02-04 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8335715002?gh_jid=8335715002) |
-| 🔥 Lyft | Data Scientist, Algorithms, Optimization - Fulfillment | New York, NY | 2026-02-04 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8335733002?gh_jid=8335733002) |
-| 🔥 Lyft | Data Scientist, Algorithms, ML - Fulfillment | Seattle, WA | 2026-02-04 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8405008002?gh_jid=8405008002) |
-| 🔥 Lyft | Data Scientist, Algorithms, ML - Fulfillment | New York, NY | 2026-02-04 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8404976002?gh_jid=8404976002) |
-| 🚀 Grammarly | Data Scientist | San Francisco; Hybrid | 2026-02-04 | [Apply](https://job-boards.greenhouse.io/grammarly/jobs/6458934) |
-| 🔥 Lyft | Data Scientist - Optimization, Pricing/Rider Engagement | New York, NY | 2026-02-04 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8403385002?gh_jid=8403385002) |
-| 🔥 Lyft | Data Scientist - Optimization, Pricing/Rider Engagement | San Francisco, CA | 2026-02-04 | [Apply](https://app.careerpuck.com/job-board/lyft/job/8402838002?gh_jid=8402838002) |
-| LaunchDarkly | Data Scientist, Data Science | Remote - US | 2026-02-04 | [Apply](https://job-boards.greenhouse.io/launchdarkly/jobs/7617683003) |
-| 🚀 Twitch | Data Scientist | San Francisco, CA | 2026-02-03 | [Apply](https://job-boards.greenhouse.io/twitch/jobs/8401220002) |
-| 🚀 Plaid | Data Scientist - Network Value | San Francisco | 2026-01-31 | [Apply](https://jobs.lever.co/plaid/18503c02-17a0-4c47-98c8-155b0b6ccc2a) |
-| Contentful | Data Scientist | Denver, Colorado, United States | 2026-01-24 | [Apply](https://job-boards.greenhouse.io/contentful/jobs/7548713) |
-| Spotify | Machine Learning Engineer - Ad Forecasting | New York, NY | 2026-01-20 | [Apply](https://jobs.lever.co/spotify/e0bb55eb-89be-406a-8d90-48f58f63dd20) |
-| Aon | Actuarial Data Scientist | KA, IN | 3 days ago | [Apply](https://in.indeed.com/viewjob?jk=24d631ad64674c31) |
-| TD | Data Scientist III | Toronto, ON, CA | 1 day ago | [Apply](https://ca.indeed.com/viewjob?jk=9756235df542cc8a) |
-| TD | Data Scientist III | Toronto, ON, CA | 2 days ago | [Apply](https://ca.indeed.com/viewjob?jk=f902f6a67794dc10) |
-| 🔥 Visa | Data Scientist, (AI/ML) – Visa Consulting and Analytics | Toronto, ON, CA | 6 days ago | [Apply](https://ca.indeed.com/viewjob?jk=af6f836e4984913d) |
-| Thomson Reuters | Al Engineer, Materia (New Grad - 2026) | Toronto, ON, CA | 1 day ago | [Apply](https://ca.indeed.com/viewjob?jk=498801eb00e34f7f) |
-| Premera Blue Cross | AI/Data Scientist II | Remote, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=1ea032120825aad4) |
-| Narsee Monjee Institute of Management Studies | Associate Professor - Artificial Intelligence and Machine Learning | MH, IN | 2026-03-05 | [Apply](https://in.indeed.com/viewjob?jk=f01232ab016c43d2) |
-| Moes Group | Junior AI Engineer (LLM / OpenClaw) | Chatsworth, CA, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=f7f370f6bcabd2bb) |
-| 🔥 NVIDIA | Silicon Co-Design Engineer - New College Grad 2026 | Santa Clara, CA, US | 2 days ago | [Apply](https://www.indeed.com/viewjob?jk=bca840f9b581f3ba) |
-| 🔥 Apple | Finance Data Scientist - Accounting and Risk | Austin, TX, US | 3 days ago | [Apply](https://www.indeed.com/viewjob?jk=1093705893ab6ac4) |
-| 🔥 Apple | Machine Learning Engineer - Product Marketing Customer Analytics | Cupertino, CA, US | 3 days ago | [Apply](https://www.indeed.com/viewjob?jk=5125af58cec04f52) |
-| 🔥 Visa | Data Scientist, AI/ML – Visa Consulting and Analytics | Atlanta, GA, US | 6 days ago | [Apply](https://www.indeed.com/viewjob?jk=de9b1266ec52174f) |
-| 🔥 Apple | Machine Learning Engineer | Austin, TX, US | 3 days ago | [Apply](https://www.indeed.com/viewjob?jk=f4d42ef7e05235f2) |
-| 🔥 Apple | Machine Learning Engineer | Austin, TX, US | 3 days ago | [Apply](https://www.indeed.com/viewjob?jk=6b2c995c5f299fe9) |
-| 🔥 Apple | Machine Learning Engineer | Austin, TX, US | 3 days ago | [Apply](https://www.indeed.com/viewjob?jk=5d3cbed677175422) |
-| United Federal Credit Union | Data Scientist | US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=40cfe02d82264a50) |
-| 🔥 Adobe | Machine Learning Engineer 2 | Noida | 2026-02-14 | [Apply](https://adobe.wd5.myworkdayjobs.com/job/Noida/Machine-Learning-Engineer-2_R165280) |
-| 🔥 PayPal | Data Scientist 1 | San Jose, California, United States of America | 1 day ago | [Apply](https://paypal.wd1.myworkdayjobs.com/job/San-Jose-California-United-States-of-America/Data-Scientist-1_R0135485) |
-| Workday | Machine Learning Engineer III | USA, CO, Boulder | 6 days ago | [Apply](https://workday.wd5.myworkdayjobs.com/job/USA-CO-Boulder/Machine-Learning-Engineer_JR-0104464) |
-| Citi | Data Scientist, Generative AI - Spread Products | New York New York United States | Today | [Apply](https://citi.wd5.myworkdayjobs.com/job/New-York-New-York-United-States/Data-Scientist--Generative-AI---Spread-Products_26940304) |
+| xAI | Data Engineer | Palo Alto, CA | Today | [Apply](https://job-boards.greenhouse.io/xai/jobs/5120884007) |
+| 🚀 OpenAI | Founding Data Scientist, Pricing & Monetization | San Francisco, California, United States | Today | [Apply](https://jobs.ashbyhq.com/openai/e5e1a914-79b6-4cf5-929a-01671d8ec4cd) |
+| 🚀 Roblox | [2026] Data Scientist, Social | San Mateo, CA, United States | Today | [Apply](https://careers.roblox.com/jobs/7463634?gh_jid=7463634) |
+| 🚀 SpaceX | Data Engineer (Starlink Network Analytics, Wi-Fi) | Redmond, WA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8573711002?gh_jid=8573711002) |
+| 🚀 SpaceX | ML Engineer, Surrogate Modeling (Vehicle Engineering) | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8559035002?gh_jid=8559035002) |
+| 🚀 SpaceX | Site Reliability Engineer (Top Secret Clearance) | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8601223002?gh_jid=8601223002) |
+| 🔥 Airbnb | Data Scientist, Trust (ML/Algorithms) | Remote - USA | Today | [Apply](https://careers.airbnb.com/positions/8059212?gh_jid=8059212) |
+| 🔥 Airbnb | Data Scientist, Platform | United States | Today | [Apply](https://careers.airbnb.com/positions/7904127?gh_jid=7904127) |
+| 🔥 Airbnb | Data Scientist - Inference, Community Support | Remote - USA | Today | [Apply](https://careers.airbnb.com/positions/8031907?gh_jid=8031907) |
+| 🔥 Airbnb | Data Scientist - Algorithms, Community Support | Remote - USA | Today | [Apply](https://careers.airbnb.com/positions/8031901?gh_jid=8031901) |
+
+**[→ View all 148 Data Science & ML roles on the live board](https://jobs.riteshrana.engineer/)**
 
 ## 📊 Data Engineering New Grad Roles
 
@@ -864,25 +192,18 @@
 
 | Company | Role | Location | Posted | Apply |
 |---------|------|----------|--------|-------|
-| 🚀 Samsara | Data Engineer II | Remote - US | Today | [Apply](https://www.samsara.com/company/careers/roles/7650290?gh_jid=7650290) |
-| 🚀 SpaceX | Data Engineer (Starlink Growth) | Hawthorne, CA | 1 day ago | [Apply](https://boards.greenhouse.io/spacex/jobs/8240611002?gh_jid=8240611002) |
-| 🚀 SpaceX | Data Engineer (Starlink Growth) | Redmond, WA | 1 day ago | [Apply](https://boards.greenhouse.io/spacex/jobs/8243150002?gh_jid=8243150002) |
-| Contentful | Data Engineer | Denver, Colorado, United States | 1 day ago | [Apply](https://job-boards.greenhouse.io/contentful/jobs/7544099) |
-| 🔥 Lyft | Data Engineer, Growth Platforms | Toronto, Canada | 2 days ago | [Apply](https://app.careerpuck.com/job-board/lyft/job/8448184002?gh_jid=8448184002) |
-| 🚀 SoFi | Data Engineer | TX - Frisco | 2026-03-04 | [Apply](https://sofi.com/careers/job/7647791003?gh_jid=7647791003) |
-| 🚀 Discord | Data Engineer, Analytics | San Francisco Bay Area | 2026-02-20 | [Apply](https://job-boards.greenhouse.io/discord/jobs/8371252002) |
-| 🚀 SpaceX | Data Engineer (Direct To Cell) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8391768002?gh_jid=8391768002) |
-| 🚀 SpaceX | Data Engineer, Ground Network Engineering (Gateway)  | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8192168002?gh_jid=8192168002) |
-| 🚀 SpaceX | Data Engineer - Top Secret Clearance (Application Software, Data) 🇺🇸 | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8299581002?gh_jid=8299581002) |
-| Fi.span | Data Engineer - I | Vancouver, BC, CA | 3 days ago | [Apply](https://ca.indeed.com/viewjob?jk=05b730c69957aaf4) |
-| University System of New Hampshire | Workday/Fabric Data Engineer | Concord, NH, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=ff8f25a3a62b6511) |
-| Nationwide Mutual Insurance Company | Specialist, Data Engineer | Columbus, OH, US | 3 days ago | [Apply](https://www.indeed.com/viewjob?jk=11c8452bdf60974b) |
-| Quorum Software | Data Engineer I (Base Camp) | Houston, TX, US | 6 days ago | [Apply](https://www.indeed.com/viewjob?jk=69d0977bad9433e9) |
-| Quorum Software | Data Engineer I (Base Camp) | Dallas, TX, US | 6 days ago | [Apply](https://www.indeed.com/viewjob?jk=4a5eb975a37e3115) |
-| Quorum Business Solutions | Data Engineer I (Base Camp) | Dallas, TX, US | 6 days ago | [Apply](https://www.indeed.com/viewjob?jk=59a4bbdbdd64fe68) |
-| Quorum Business Solutions | Data Engineer I (Base Camp) | Houston, TX, US | 6 days ago | [Apply](https://www.indeed.com/viewjob?jk=ba37e62a9a87f91a) |
-| Wallick Communities | Data Engineer | New Albany, OH, US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=274c531501daa94e) |
-| Pfizer | AI Data Engineer--LLMs / Agentic Systems | United States - Massachusetts - Cambridge | 2026-03-05 | [Apply](https://pfizer.wd1.myworkdayjobs.com/job/United-States---Massachusetts---Cambridge/AI-Data-Engineer--LLMs---Agentic-Systems_4952924-1) |
+| Precision Medicine Group | Client Services Business Analyst I - Healthcare Data | Indianapolis, IN, USA | Today | [Apply](https://job-boards.greenhouse.io/precisionmedicinegroup/jobs/5797573004) |
+| Precision Medicine Group | Client Services Business Analyst II - Healthcare Data | Indianapolis, IN, USA | Today | [Apply](https://job-boards.greenhouse.io/precisionmedicinegroup/jobs/5779250004) |
+| Precision Medicine Group | Power BI Developer II | Bangalore, Karnataka, India | Today | [Apply](https://job-boards.greenhouse.io/precisionmedicinegroup/jobs/6005640004) |
+| 🚀 Dropbox | Data Engineer | Remote - Poland | Today | [Apply](https://jobs.dropbox.com/listing/8053628?gh_jid=8053628) |
+| 🚀 Dropbox | Data Engineer | Remote - Mexico | Today | [Apply](https://jobs.dropbox.com/listing/7739553?gh_jid=7739553) |
+| 🚀 SpaceX | Data Infrastructure Operations Specialist II (Starlink) | Redmond, WA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8508424002?gh_jid=8508424002) |
+| 🚀 MongoDB | Site Reliability Engineer 3 | New York City | Today | [Apply](https://www.mongodb.com/careers/job/?gh_jid=7821316) |
+| SingleStore | Site Reliability Engineer | Seattle | Today | [Apply](https://job-boards.greenhouse.io/singlestore/jobs/7432205) |
+| SingleStore | Site Reliability Engineer | India | Today | [Apply](https://job-boards.greenhouse.io/singlestore/jobs/7533846) |
+| LPL Financial | Associate Engineer - Data and Batch Operations | TS, IN | Today | [Apply](https://in.indeed.com/viewjob?jk=322f8bcd49aad413) |
+
+**[→ View all 27 Data Engineering roles on the live board](https://jobs.riteshrana.engineer/)**
 
 ## 🏗️ Infrastructure & SRE New Grad Roles
 
@@ -890,115 +211,18 @@
 
 | Company | Role | Location | Posted | Apply |
 |---------|------|----------|--------|-------|
-| 🚀 SpaceX | Network Engineer (Starshield) | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8375288002?gh_jid=8375288002) |
-| Amplitude | AI Security Engineer | San Francisco, CA | Today | [Apply](https://job-boards.greenhouse.io/amplitude/jobs/8399495002) |
-| 🚀 SpaceX | IT Network Infrastructure Engineer, Launch | Starbase, TX | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8458745002?gh_jid=8458745002) |
-| 🚀 Scale AI | Security Engineer, Infrastructure & Security | St. Louis, MO; Washington, DC | Today | [Apply](https://job-boards.greenhouse.io/scaleai/jobs/4651559005) |
-| 🚀 Scale AI | AI Infrastructure Engineer, Core Infrastructure | San Francisco, CA; Seattle, WA; New York, NY | Today | [Apply](https://job-boards.greenhouse.io/scaleai/jobs/4624681005) |
-| 🚀 Scale AI | AI Infrastructure Engineer, Model Serving Platform | San Francisco, CA; New York, NY | Today | [Apply](https://job-boards.greenhouse.io/scaleai/jobs/4520320005) |
-| Gusto | Retirement Developer Infrastructure Engineer | Denver, CO;San Francisco, CA;New York, NY | Today | [Apply](https://job-boards.greenhouse.io/gusto/jobs/7615358) |
-| Tanium | AI Security Engineer | Addison, TX (Hybrid); Durham, NC (Hybrid); Emeryville, CA (Hybrid); Remote, US | Today | [Apply](https://job-boards.greenhouse.io/tanium/jobs/7487567) |
-| 🚀 Chime | Product Security Engineer | San Francisco, CA, USA | Today | [Apply](https://boards.greenhouse.io/chime/jobs/8141068002?gh_jid=8141068002) |
-| 🚀 SpaceX | Product Security Engineer (Starlink) | Redmond, WA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8459547002?gh_jid=8459547002) |
-| 🚀 SpaceX | Embedded Security Engineer (Starlink) | Redmond, WA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8459556002?gh_jid=8459556002) |
-| 🚀 SpaceX | Product Security Engineer (Starlink) | Bastrop, TX | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8459575002?gh_jid=8459575002) |
-| 🚀 SpaceX | Embedded Security Engineer (Starlink) | Bastrop, TX | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8459579002?gh_jid=8459579002) |
-| 🚀 SpaceX | Product Security Engineer (Starlink) | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8459615002?gh_jid=8459615002) |
-| 🚀 SpaceX | Embedded Security Engineer (Starlink) | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8459609002?gh_jid=8459609002) |
-| Gusto | AI Security Engineer | San Francisco, CA | Today | [Apply](https://job-boards.greenhouse.io/gusto/jobs/7590298) |
-| ZoomInfo | DevOps Engineer III | Waltham, Massachusetts, United States | Today | [Apply](https://www.zoominfo.com/careers?gh_jid=8451384002) |
-| Riot Games | Network Engineer II | Los Angeles, USA | 1 day ago | [Apply](https://www.riotgames.com/en/work-with-us/job/7437697?gh_jid=7437697) |
-| 🚀 Robinhood | Technical Sourcer, Infrastructure Engineering | Toronto, Canada | 1 day ago | [Apply](https://boards.greenhouse.io/robinhood/jobs/7630005?t=gh_src=&gh_jid=7630005) |
-| 🚀 Coinbase | Blockchain Security Engineer | Remote - USA | 1 day ago | [Apply](https://www.coinbase.com/careers/positions/7701657?gh_jid=7701657) |
-| 🚀 Robinhood | Technical Sourcer, Infrastructure Engineering | Chicago, IL | 1 day ago | [Apply](https://boards.greenhouse.io/robinhood/jobs/7630003?t=gh_src=&gh_jid=7630003) |
-| 🚀 Palantir | Forward Deployed Security Engineer - US Government | Washington, D.C. | 2 days ago | [Apply](https://jobs.lever.co/palantir/22053072-4c22-49c4-8299-28e107ceeb98) |
-| 🚀 MongoDB | IAM Security Engineer 3 | United States | 2 days ago | [Apply](https://www.mongodb.com/careers/job/?gh_jid=7656724) |
-| 🚀 MongoDB | Site Reliability Engineer 3 | New York City | 2 days ago | [Apply](https://www.mongodb.com/careers/job/?gh_jid=7145126) |
-| 🚀 SpaceX | Site Reliability Engineer - Top Secret Clearance 🇺🇸 | Hawthorne, CA | 5 days ago | [Apply](https://boards.greenhouse.io/spacex/jobs/8362795002?gh_jid=8362795002) |
-| 🔥 Stripe | Security Engineer, Bridge | SF, New York, Seattle | 5 days ago | [Apply](https://stripe.com/jobs/search?gh_jid=7573236) |
-| 🔥 Stripe | Security Engineer, New Grad  | Seattle, WA; San Francisco, CA; Toronto, CAN | 5 days ago | [Apply](https://stripe.com/jobs/search?gh_jid=7477571) |
-| 🚀 GitLab | Intermediate Site Reliability Engineer, Environment Automation | Remote, France; Remote, Germany; Remote, Ireland; Remote, Israel; Remote, Netherlands; Remote, Spain; Remote, United Kingdom | 5 days ago | [Apply](https://job-boards.greenhouse.io/gitlab/jobs/8242652002) |
-| 🚀 GitLab | Intermediate Site Reliability Engineer, Tenant Scale: Tenant Services | Remote, Americas; Remote, EMEA | 5 days ago | [Apply](https://job-boards.greenhouse.io/gitlab/jobs/8358825002) |
-| LaunchDarkly | Infrastructure Engineer | Remote - US | 5 days ago | [Apply](https://job-boards.greenhouse.io/launchdarkly/jobs/7655955003) |
-| Wiz | Security Engineer - Product & Production Infrastructure | Remote - Ireland | 5 days ago | [Apply](https://www.wiz.io/careers/job/4595652006/:title?gh_jid=4595652006) |
-| Wiz | Security Engineer - Product & Production Infrastructure | Remote - Netherlands | 5 days ago | [Apply](https://www.wiz.io/careers/job/4595651006/:title?gh_jid=4595651006) |
-| Wiz | Security Engineer - Product & Production Infrastructure | Remote - Germany | 5 days ago | [Apply](https://www.wiz.io/careers/job/4595650006/:title?gh_jid=4595650006) |
-| Wiz | Security Engineer - Product & Production Infrastructure | Remote - France | 5 days ago | [Apply](https://www.wiz.io/careers/job/4595653006/:title?gh_jid=4595653006) |
-| Wiz | Security Engineer - Product & Production Infrastructure | Remote - United Kingdom | 5 days ago | [Apply](https://www.wiz.io/careers/job/4579802006/:title?gh_jid=4579802006) |
-| Wiz | Security Engineer II - SaaS Applications | Remote - USA | 5 days ago | [Apply](https://www.wiz.io/careers/job/4650182006/:title?gh_jid=4650182006) |
-| Wiz | Security Engineer - Product & Production Infrastructure | Remote - USA | 5 days ago | [Apply](https://www.wiz.io/careers/job/4421449006/:title?gh_jid=4421449006) |
-| 🚀 Coinbase | Security Engineer, CorpSec | Remote - USA | 6 days ago | [Apply](https://www.coinbase.com/careers/positions/7611268?gh_jid=7611268) |
-| 🚀 Coinbase | Site Reliability Engineer, IT Infrastructure | Remote - USA | 6 days ago | [Apply](https://www.coinbase.com/careers/positions/7559168?gh_jid=7559168) |
-| 🚀 SpaceX | Network Security Engineer | Hawthorne, CA | 6 days ago | [Apply](https://boards.greenhouse.io/spacex/jobs/8208775002?gh_jid=8208775002) |
-| PagerDuty | Site Reliability Engineer II | Toronto | 6 days ago | [Apply](https://job-boards.greenhouse.io/pagerduty/jobs/5792400004) |
-| 🚀 Dropbox | Network Engineer | Remote - Poland | 2026-03-04 | [Apply](https://jobs.dropbox.com/listing/7536991?gh_jid=7536991) |
-| 🚀 Dropbox | Network Engineer | Remote - Mexico | 2026-03-04 | [Apply](https://jobs.dropbox.com/listing/7539803?gh_jid=7539803) |
-| 🚀 Dropbox | Site Reliability Engineer | Remote - Mexico | 2026-03-04 | [Apply](https://jobs.dropbox.com/listing/7539817?gh_jid=7539817) |
-| Flatiron Health | Application Security Engineer | NY office | 2026-02-27 | [Apply](https://flatiron.com/careers/open-positions/job?gh_jid=7512197) |
-| Opendoor | Infrastructure Engineer | Toronto | 2026-02-26 | [Apply](https://www.opendoor.com/careers/open-positions?gh_jid=4643093006) |
-| Opendoor | Infrastructure Engineer | Office - Washington-Seattle; Toronto | 2026-02-26 | [Apply](https://www.opendoor.com/careers/open-positions?gh_jid=4643092006) |
-| 🚀 Databricks | Product Security Engineer | United States | 2026-02-25 | [Apply](https://databricks.com/company/careers/open-positions/job?gh_jid=8026646002) |
-| 🚀 SpaceX | Application Security Engineer | Hawthorne, CA | 2026-02-20 | [Apply](https://boards.greenhouse.io/spacex/jobs/8426398002?gh_jid=8426398002) |
-| Contentful | Security Engineer | New York City, New York, United States | 2026-02-20 | [Apply](https://job-boards.greenhouse.io/contentful/jobs/7536572) |
-| Fireblocks | Site Reliability Engineer | United States | 2026-02-19 | [Apply](https://job-boards.greenhouse.io/fireblocks/jobs/4656035006) |
-| 🚀 Airtable | Product Security Engineer | San Francisco, CA; New York, NY; Remote (Seattle, WA only) | 2026-02-17 | [Apply](https://job-boards.greenhouse.io/airtable/jobs/8194662002) |
-| 🚀 SpaceX | Security Engineer (Blue Team) | Redmond, WA | 2026-02-17 | [Apply](https://boards.greenhouse.io/spacex/jobs/8426423002?gh_jid=8426423002) |
-| 🚀 SpaceX | Security Engineer (Blue Team) | Hawthorne, CA | 2026-02-17 | [Apply](https://boards.greenhouse.io/spacex/jobs/8426411002?gh_jid=8426411002) |
-| 🚀 SpaceX | Product Security Engineer (Starshield) | Washington, DC | 2026-02-17 | [Apply](https://boards.greenhouse.io/spacex/jobs/8425940002?gh_jid=8425940002) |
-| 🚀 SpaceX | Product Security Engineer (Starshield) | Hawthorne, CA | 2026-02-17 | [Apply](https://boards.greenhouse.io/spacex/jobs/8425936002?gh_jid=8425936002) |
-| Starburst | Application Security Engineer | Boston, MA | 2026-02-17 | [Apply](https://job-boards.greenhouse.io/starburst/jobs/5119301008) |
-| 🚀 SpaceX | Facilities Infrastructure Engineer | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8381785002?gh_jid=8381785002) |
-| 🚀 SpaceX | IT Network Engineer | Starbase, TX | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8399515002?gh_jid=8399515002) |
-| 🚀 SpaceX | Kubernetes Platform Infrastructure Engineer (Starlink) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8391130002?gh_jid=8391130002) |
-| 🚀 SpaceX | Network Engineer (Starlink) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8213701002?gh_jid=8213701002) |
-| 🚀 SpaceX | Network Engineer (Starlink Community Gateway) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8406017002?gh_jid=8406017002) |
-| 🚀 SpaceX | Network Engineer (Starshield) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8392855002?gh_jid=8392855002) |
-| 🚀 SpaceX | Security Engineer (Security Operations) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8208779002?gh_jid=8208779002) |
-| 🚀 SpaceX | Security Engineer (Security Operations) | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8201865002?gh_jid=8201865002) |
-| 🚀 SpaceX | Site Reliability Engineer, GNC (Falcon) | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8209991002?gh_jid=8209991002) |
-| 🚀 SpaceX | Software Infrastructure Engineer (Starlink) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8391128002?gh_jid=8391128002) |
-| ClickHouse | Product Security Engineer | Germany (remote) | 2026-02-12 | [Apply](https://job-boards.greenhouse.io/clickhouse/jobs/5802967004) |
-| Sumo Logic | Site Reliability Engineer - I, Product Area Focus | Noida, Uttar Pradesh, India | 2026-02-09 | [Apply](https://job-boards.greenhouse.io/sumologic/jobs/7579928) |
-| 🚀 Unity Technologies | Network Engineer | Remote, United Kingdom | 2026-02-09 | [Apply](https://unity.com/careers/positions/7288934?gh_jid=7288934) |
-| Fireblocks | Site Reliability Engineer (SRE) (Pacific time) | United States | 2026-02-06 | [Apply](https://job-boards.greenhouse.io/fireblocks/jobs/4619316006) |
-| 🚀 Cloudflare | Application Security Engineer | Hybrid; In-Office | 2026-02-06 | [Apply](https://boards.greenhouse.io/cloudflare/jobs/7185996?gh_jid=7185996) |
-| 🚀 Cloudflare | IAM Security Engineer | Hybrid; In-Office | 2026-02-06 | [Apply](https://boards.greenhouse.io/cloudflare/jobs/7483707?gh_jid=7483707) |
-| Spotify | Site Reliability Engineer - Backstage | New York, NY | 2026-02-05 | [Apply](https://jobs.lever.co/spotify/ad5ef898-b800-4213-a63e-e39a97df9cfb) |
-| SingleStore | Site Reliability Engineer | India | 2026-01-21 | [Apply](https://job-boards.greenhouse.io/singlestore/jobs/7432205) |
-| 🚀 Grammarly | Site Reliability Engineer | San Francisco; Hybrid | 2026-01-16 | [Apply](https://job-boards.greenhouse.io/grammarly/jobs/6994860) |
-| Hatch | Electrical Engineering Trainee | Greater Sudbury, ON, CA | 2026-02-21 | [Apply](https://ca.indeed.com/viewjob?jk=09b983c8cd9efad7) |
-| Hatch | Control & Automation Engineering Trainee | Greater Sudbury, ON, CA | 2026-02-21 | [Apply](https://ca.indeed.com/viewjob?jk=e6e4bb6b171eb63d) |
-| Omada Rail Systems | Junior Geotechnical Engineer | Hamilton, ON, CA | 1 day ago | [Apply](https://ca.indeed.com/viewjob?jk=64121155a6876c4f) |
-| NTT DATA | Network Engineer | KA, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=4f253299241dc441) |
-| Bitchief Technology Services Pvt. Ltd  | Cyber Security Trainee | HR, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=97e4458cc74909df) |
-| Syniverse | Associate Cybersecurity Engineer | KA, IN | 3 days ago | [Apply](https://in.indeed.com/viewjob?jk=61ac3dfb4d2a2be8) |
-| DataBank | Jr. Critical Infrastructure Engineer | Atlanta, GA, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=6ccc3080bbac6689) |
-| DataBank | Jr. Critical Infrastructure Engineer | Plano, TX, US | 3 days ago | [Apply](https://www.indeed.com/viewjob?jk=6d8cbf0fb921388c) |
-| DataBank | Jr. Critical Infrastructure Engineer | Ashburn, VA, US | 2026-02-09 | [Apply](https://www.indeed.com/viewjob?jk=cfe3c98ec1f042c2) |
-| TD | TD Gen AI Hackathon - University of Toronto (March 14-15) Associate Engineer I - AI Platform Applicants | Toronto, ON, CA | 1 day ago | [Apply](https://ca.indeed.com/viewjob?jk=4e7a481367eb9fb1) |
-| 🔥 Lockheed Martin | System Integration and Test Engineer Associate | Halifax, NS, CA | 1 day ago | [Apply](https://ca.indeed.com/viewjob?jk=07f60e470ee2cec0) |
-| Deutsche Bank | Associate Engineer | MH, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=867f493ba11cd46b) |
-| Siemens | DevOps Engineer - AWS, Teamwork Cloud, MagicDraw | MH, IN | 3 days ago | [Apply](https://in.indeed.com/viewjob?jk=c10801e799b58971) |
-| New Mexico State University | SEN NOC Network Engineer | Las Cruces, NM, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=21a39f18b2fd1197) |
-| CHRISTUS Health | Information Technology Engineer I - Network Engineer | San Antonio, TX, US | 2026-02-28 | [Apply](https://www.indeed.com/viewjob?jk=400ad05d93d0e589) |
-| Ferguson | Sales Trainee Program - June | Lakewood, NJ, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=e3aa6c20e67ba100) |
-| Aptiv | DevOps Engineer – Jenkins CI/CD, Kubernetes, Docker, Linux | KA, IN | 2026-01-27 | [Apply](https://in.indeed.com/viewjob?jk=b3def4e6b89f101c) |
-| Kore.ai | DevOPS Engineer | San Mateo, CA, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=0c3c7f49d5917156) |
-| LIVIC Civil | Entry Level Civil Engineer / Designer - Infrastructure | Bloomsburg, PA, US | 6 days ago | [Apply](https://www.indeed.com/viewjob?jk=92e8fde4b8bb1088) |
-| LIVIC Civil | Entry Level Civil Engineer / Designer - Infrastructure | Montoursville, PA, US | 6 days ago | [Apply](https://www.indeed.com/viewjob?jk=33eeef6b50b1d6d1) |
-| LIVIC Civil | Entry Level Civil Engineer / Designer - Infrastructure | Northumberland, PA, US | 6 days ago | [Apply](https://www.indeed.com/viewjob?jk=cf33decdb76723e6) |
-| LIVIC Civil | Entry Level Civil Engineer / Designer - Infrastructure | Wormleysburg, PA, US | 6 days ago | [Apply](https://www.indeed.com/viewjob?jk=e149f272338895aa) |
-| 🔥 Adobe | Product Security Engineer 4 | Bangalore | 6 days ago | [Apply](https://adobe.wd5.myworkdayjobs.com/job/Bangalore/Product-Security-Engineer-4_R166129) |
-| 🔥 Adobe | Site Reliability Engineer 4 | Bangalore | 2026-02-10 | [Apply](https://adobe.wd5.myworkdayjobs.com/job/Bangalore/Site-Reliability-Engineer-4_R162488) |
-| 🔥 Adobe | Site Reliability Engineer - 4 | Bangalore | 2026-02-10 | [Apply](https://adobe.wd5.myworkdayjobs.com/job/Bangalore/Site-Reliability-Engineer---4_R162484) |
-| 🔥 NVIDIA | Firmware Infrastructure Engineer - GPU | US, CA, Santa Clara | Today | [Apply](https://nvidia.wd5.myworkdayjobs.com/job/US-CA-Santa-Clara/Firmware-Infrastructure-Engineer---GPU_JR1999623-1) |
-| 🔥 Intel | Software DevOps Engineer | US, Oregon, Hillsboro | Today | [Apply](https://intel.wd1.myworkdayjobs.com/job/US-Oregon-Hillsboro/Software-DevOps-Engineer_JR0281813) |
-| 🔥 Intel | Infrastructure and DevOps Engineer | US, Oregon, Hillsboro | 6 days ago | [Apply](https://intel.wd1.myworkdayjobs.com/job/US-Oregon-Hillsboro/Infrastructure-and-DevOps-Engineer_JR0281488) |
-| 🔥 Autodesk | Application Security Engineer | Bengaluru, IND | Today | [Apply](https://autodesk.wd1.myworkdayjobs.com/job/Bengaluru-IND/Application-Security-Engineer_26WD95373-1) |
-| 🔥 Northrop Grumman | Systems Security Engineer Level 3 / 4 | United States-Illinois-Rolling Meadows | 1 day ago | [Apply](https://ngc.wd1.myworkdayjobs.com/job/United-States-Illinois-Rolling-Meadows/Systems-Security-Engineer-Level-3---4_R10225530) |
-| 🔥 Northrop Grumman | DevOps Engineer | United States-Colorado-Colorado Springs | 1 day ago | [Apply](https://ngc.wd1.myworkdayjobs.com/job/United-States-Colorado-Colorado-Springs/DevOps-Engineer_R10225395) |
-| 🔥 Boeing | Product Security Engineer, Associate | USA - Hazelwood, MO | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---Hazelwood-MO/Product-Security-Engineer--Product-Security-Engineer-_JR2025488464) |
-| 🔥 Boeing | Product Security Engineer, Mid-Level | USA - Hazelwood, MO | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---Hazelwood-MO/Product-Security-Engineer--Product-Security-Engineer-_JR2025488469) |
+| xAI | Associate Data Center Operations Technician | Memphis, TN; Southaven, MS | Today | [Apply](https://job-boards.greenhouse.io/xai/jobs/5168434007) |
+| xAI | Facilities Infrastructure Engineer (Data Center Infrastructure) | Memphis, TN; Southaven, MS | Today | [Apply](https://job-boards.greenhouse.io/xai/jobs/5182374007) |
+| xAI | Network Engineer | Memphis, TN | Today | [Apply](https://job-boards.greenhouse.io/xai/jobs/4870731007) |
+| xAI | Network Engineer - ML Infrastructure (High-Speed Interconnects) | Palo Alto, CA | Today | [Apply](https://job-boards.greenhouse.io/xai/jobs/5043570007) |
+| xAI | Network Security Engineer | Palo Alto, CA | Today | [Apply](https://job-boards.greenhouse.io/xai/jobs/4800712007) |
+| xAI | Software Engineer - Networking Software and Services | Palo Alto, CA | Today | [Apply](https://job-boards.greenhouse.io/xai/jobs/4946696007) |
+| Precision Medicine Group | QA Engineer I | Remote, India | Today | [Apply](https://job-boards.greenhouse.io/precisionmedicinegroup/jobs/6105760004) |
+| 🚀 SpaceX | Facilities Infrastructure Engineer | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8381785002?gh_jid=8381785002) |
+| 🚀 SpaceX | Flight Software Infrastructure Engineer (Starlink) | Redmond, WA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8477451002?gh_jid=8477451002) |
+| 🚀 SpaceX | Infrastructure Engineer | Redmond, WA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8604308002?gh_jid=8604308002) |
+
+**[→ View all 122 Infrastructure & SRE roles on the live board](https://jobs.riteshrana.engineer/)**
 
 ## 📱 Product Management New Grad Roles
 
@@ -1006,9 +230,9 @@
 
 | Company | Role | Location | Posted | Apply |
 |---------|------|----------|--------|-------|
-| MongoDB | Software Engineer 3, Voyage Control Plane | Palo Alto; Seattle | Today | [Apply](https://www.mongodb.com/careers/job/?gh_jid=8041664) |
+| 🚀 MongoDB | Software Engineer 3, Voyage Control Plane | Palo Alto; Seattle | Today | [Apply](https://www.mongodb.com/careers/job/?gh_jid=8041664) |
 | Telus | AI Innovation Associate (Vibe Coder) - Channel Technology and Sales Strategy Team | Toronto, ON, CA | 1 day ago | [Apply](https://ca.indeed.com/viewjob?jk=c040cfa3243204f4) |
-| Cerebras | Hardware / Low Level Security Engineer | US and Canada Offices | 2026-06-23 | [Apply](https://jobs.ashbyhq.com/cerebras/4e706d0d-65a6-4a36-9ff3-b9e9da16a618) |
+| 🚀 Cerebras | Hardware / Low Level Security Engineer | US and Canada Offices | 2026-06-23 | [Apply](https://jobs.ashbyhq.com/cerebras/4e706d0d-65a6-4a36-9ff3-b9e9da16a618) |
 
 ## 📈 Quantitative Finance New Grad Roles
 
@@ -1016,10 +240,10 @@
 
 | Company | Role | Location | Posted | Apply |
 |---------|------|----------|--------|-------|
-| TD | Associate - Quant Engineering and Development | Toronto, ON, CA | 2 days ago | [Apply](https://ca.indeed.com/viewjob?jk=3da5343bd3e269a5) |
-| Palantir | Deployment Strategist, New Grad - Intel, US Government | Washington, D.C. | 2026-06-15 | [Apply](https://jobs.lever.co/palantir/5d8286d6-992a-404b-94af-99c173d40299) |
 | 🚀 SpaceX | Customer Support Associate, Bilingual - Ukrainian (Starlink) | Redmond, WA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8548098002?gh_jid=8548098002) |
 | 🚀 SpaceX | Customer Support Associate, Bilingual - Ukrainian (Starlink) | Bastrop, TX | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8548093002?gh_jid=8548093002) |
+| TD | Associate - Quant Engineering and Development | Toronto, ON, CA | 2 days ago | [Apply](https://ca.indeed.com/viewjob?jk=3da5343bd3e269a5) |
+| 🚀 Palantir | Deployment Strategist, New Grad - Intel, US Government | Washington, D.C. | 2026-06-15 | [Apply](https://jobs.lever.co/palantir/5d8286d6-992a-404b-94af-99c173d40299) |
 
 ## 🔧 Hardware Engineering New Grad Roles
 
@@ -1027,13 +251,18 @@
 
 | Company | Role | Location | Posted | Apply |
 |---------|------|----------|--------|-------|
-| 🔥 Google | Silicon Engineer, University Graduate, 2026 | KA, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=344d8fdac75c9926) |
-| University of Missouri-Kansas City | Mechanical Engineer II - Missouri Institute for Defense and Energy | Kansas City, MO, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=ccb17dc95b0e27c7) |
-| Kimley-Horn | Entry Level Mechanical Engineer - Water/Wastewater | Akron, OH, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=e40842d6badc03c8) |
-| 🔥 Qualcomm | Associate Engineer | TS, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=5e3e9adccc7ac679) |
-| 🔥 NVIDIA | Silicon Co-Design Engineer - New College Grad 2026 | US, CA, Santa Clara | 1 day ago | [Apply](https://nvidia.wd5.myworkdayjobs.com/job/US-CA-Santa-Clara/Silicon-Co-Design-Engineer---New-College-Grad-2026_JR2014451) |
-| 🔥 Northrop Grumman | Associate Antenna Test Engineer | United States-Maryland-Baltimore | Today | [Apply](https://ngc.wd1.myworkdayjobs.com/job/United-States-Maryland-Baltimore/Associate-Antenna-Test-Engineer_R10225581-1) |
-| 🔥 Northrop Grumman | Mechanical Engineer (Level 2 or 3) | United States-Minnesota-Plymouth | 1 day ago | [Apply](https://ngc.wd1.myworkdayjobs.com/job/United-States-Minnesota-Plymouth/Mechanical-Engineer--Level-2-or-3-_R10225473) |
+| 🚀 SpaceX | New Graduate Engineer, Electrical - Satellites (Starlink) | Redmond, WA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8541336002?gh_jid=8541336002) |
+| 🚀 SpaceX | New Graduate Engineer, Electrical (Starshield) | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8483305002?gh_jid=8483305002) |
+| 🚀 SpaceX | New Graduate Engineer, Mechanical (Starshield) | Hawthorne, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8493166002?gh_jid=8493166002) |
+| 🚀 SpaceX | Physical Design Engineer II (Silicon Engineering) | Austin, TX | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8533749002?gh_jid=8533749002) |
+| 🚀 SpaceX | Physical Design Engineer II (Silicon Engineering) | Irvine, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8506508002?gh_jid=8506508002) |
+| 🚀 SpaceX | Physical Design Engineer II (Silicon Engineering) | Sunnyvale, CA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8533679002?gh_jid=8533679002) |
+| Cenovus Energy | New Grad, Electrical Engineer-in-Training, June 2027 (Calgary) | Calgary, AB, CA | Today | [Apply](https://ca.indeed.com/viewjob?jk=d738807045eb8b1e) |
+| ABN Infotech Solutions | Project Engineer / Technical Support Trainee | TN, IN | Today | [Apply](https://in.indeed.com/viewjob?jk=917d2304c00a5646) |
+| 🔥 Northrop Grumman | Electrical Engineer II | United States-Arizona-Chandler | Today | [Apply](https://ngc.wd1.myworkdayjobs.com/job/United-States-Arizona-Chandler/Electrical-Engineer-II_R10240590) |
+| 🔥 Northrop Grumman | Sentinel - Mechanical Engineer level 2/3 ( *16920) | United States-Utah-Roy | Today | [Apply](https://ngc.wd1.myworkdayjobs.com/job/United-States-Utah-Roy/Sentinel---Mechanical-Engineer-level-2-3----16920-_R10239396-1) |
+
+**[→ View all 14 Hardware Engineering roles on the live board](https://jobs.riteshrana.engineer/)**
 
 ## 💼 Other New Grad Roles
 
@@ -1041,212 +270,20 @@
 
 | Company | Role | Location | Posted | Apply |
 |---------|------|----------|--------|-------|
-| Tanium | Associate Technical Support Engineer | Bellevue, WA (Hybrid); Emeryville, CA (Hybrid) | Today | [Apply](https://job-boards.greenhouse.io/tanium/jobs/7572983) |
-| Riot Games | Associate QA Engineer, Game Analysis - VALORANT | Los Angeles, USA | 1 day ago | [Apply](https://www.riotgames.com/en/work-with-us/job/7551644?gh_jid=7551644) |
-| 🚀 SpaceX | Software Engineering, Starlink Growth  | Sunnyvale, CA | 1 day ago | [Apply](https://boards.greenhouse.io/spacex/jobs/8403945002?gh_jid=8403945002) |
-| Flexport | Air Operations Associate, Gurgaon | New Delhi, Delhi, India | 1 day ago | [Apply](https://boards.greenhouse.io/flexport/jobs/7609526?gh_jid=7609526) |
-| Flexport | Inbound Sales Development Representative - New Grad | Chicago, Illinois, United States | 1 day ago | [Apply](https://boards.greenhouse.io/flexport/jobs/5850324?gh_jid=5850324) |
-| Flexport | Ocean Operations Associate, Mumbai | Mumbai Central, Maharashtra, India | 1 day ago | [Apply](https://boards.greenhouse.io/flexport/jobs/7609848?gh_jid=7609848) |
-| 🚀 Figma | Inside Sales Representative - Early Career (2026) | San Francisco, CA • New York, NY | 2 days ago | [Apply](https://boards.greenhouse.io/figma/jobs/5726175004?gh_jid=5726175004) |
-| 🚀 MongoDB | 2026 - Next in Tech Summit, NORAM | Austin; New York City; Palo Alto; San Francisco; Seattle | 2 days ago | [Apply](https://www.mongodb.com/careers/job/?gh_jid=7569187) |
-| Oscar Health | Regulatory Complaints, Associate | Remote | 2 days ago | [Apply](http://www.hioscar.com/careers/7619769?gh_jid=7619769) |
-| 🚀 Samsara | Account Development Representative (New Grad) | Phoenix, Arizona, United States | 2 days ago | [Apply](https://www.samsara.com/company/careers/roles/7607468?gh_jid=7607468) |
-| 🚀 Samsara | Account Development Representative (New Grad) | Atlanta, Georgia, United States | 2 days ago | [Apply](https://www.samsara.com/company/careers/roles/7592553?gh_jid=7592553) |
-| 🚀 Samsara | Associate Sales Engineer | Remote - UK | 2 days ago | [Apply](https://www.samsara.com/company/careers/roles/7649893?gh_jid=7649893) |
-| 🚀 Samsara | Sales Engineer II - Specialist | Remote - US | 2 days ago | [Apply](https://www.samsara.com/company/careers/roles/6782502?gh_jid=6782502) |
-| 🚀 Samsara | Sales Engineer II - Specialist | Remote - NYC | 2 days ago | [Apply](https://www.samsara.com/company/careers/roles/7341443?gh_jid=7341443) |
-| 🔥 Stripe | Operations Associate, New Grad | Bengaluru, India | 5 days ago | [Apply](https://stripe.com/jobs/search?gh_jid=7544545) |
-| 🚀 GitLab | Associate Support Engineer (AMER - PST / MST) | Remote, US | 5 days ago | [Apply](https://job-boards.greenhouse.io/gitlab/jobs/8231973002) |
-| 🚀 SpaceX | New Graduate Engineer, Software (Starlink) | Sunnyvale, CA | 5 days ago | [Apply](https://boards.greenhouse.io/spacex/jobs/8446263002?gh_jid=8446263002) |
-| 🚀 SpaceX | Electric Propulsion Engineer II (Starshield) | Hawthorne, CA | 6 days ago | [Apply](https://boards.greenhouse.io/spacex/jobs/8403176002?gh_jid=8403176002) |
-| 🚀 SpaceX | New Graduate Engineer, Electrical | Hawthorne, CA | 6 days ago | [Apply](https://boards.greenhouse.io/spacex/jobs/8136339002?gh_jid=8136339002) |
-| Gusto | Future Opportunities: Early Career Sales Talent | United States - Atlanta, GA - Remote, United States - Chicago, IL - Remote, United States - Denver, CO, United States - Las Vegas, NV - Remote, United States - Phoenix, AZ - Remote | 6 days ago | [Apply](https://job-boards.greenhouse.io/gusto/jobs/7378983) |
-| 🚀 Databricks | BDR DC (2026) | Remote - Washington D.C. | 2026-03-02 | [Apply](https://databricks.com/company/careers/open-positions/job?gh_jid=8423167002) |
-| 🚀 SpaceX | New Graduate Engineer, Software (Starlink)  | Bastrop, TX | 2026-02-27 | [Apply](https://boards.greenhouse.io/spacex/jobs/8399140002?gh_jid=8399140002) |
-| Oscar Health | Associate, Data Analytics | Tempe, Arizona, United States | 2026-02-26 | [Apply](http://www.hioscar.com/careers/7656537?gh_jid=7656537) |
-| Oscar Health | Associate, Data Analytics | Atlanta, Georgia, United States | 2026-02-26 | [Apply](http://www.hioscar.com/careers/7656540?gh_jid=7656540) |
-| Oscar Health | Associate, Data Analytics | Dallas, Texas, United States | 2026-02-26 | [Apply](http://www.hioscar.com/careers/7656538?gh_jid=7656538) |
-| Oscar Health | Associate, Data Analytics | New York, New York, United States | 2026-02-26 | [Apply](http://www.hioscar.com/careers/7648508?gh_jid=7648508) |
-| 🚀 SpaceX | NDE Inspector Trainee (Starship) - Temporary | Starbase, TX | 2026-02-25 | [Apply](https://boards.greenhouse.io/spacex/jobs/8428315002?gh_jid=8428315002) |
-| Oscar Health | Associate, Network Contracting | Remote | 2026-02-19 | [Apply](http://www.hioscar.com/careers/7638965?gh_jid=7638965) |
-| Oscar Health | Associate, Regulatory Affairs | Remote | 2026-02-19 | [Apply](http://www.hioscar.com/careers/7619737?gh_jid=7619737) |
-| 🚀 SpaceX | Machine Maintenance Associate (Starlink) | Bastrop, TX | 2026-02-16 | [Apply](https://boards.greenhouse.io/spacex/jobs/8420866002?gh_jid=8420866002) |
-| 🚀 SpaceX | Customer Support Associate, Bilingual - Ukrainian (Starlink) | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8245047002?gh_jid=8245047002) |
-| 🚀 SpaceX | Customer Support Associate, Bilingual - Ukrainian (Starlink) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8245053002?gh_jid=8245053002) |
-| 🚀 SpaceX | Customer Support Associate, Bilingual - Ukrainian (Starlink) | Bastrop, TX | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8245064002?gh_jid=8245064002) |
-| 🚀 SpaceX | New Graduate Engineer, Electrical - Satellites (Starlink)  | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8407346002?gh_jid=8407346002) |
-| 🚀 SpaceX | New Graduate Engineer, Electrical (Starlink) | Bastrop, TX | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8148530002?gh_jid=8148530002) |
-| 🚀 SpaceX | New Graduate Engineer, Mechanical (Cape Canaveral)  | Cape Canaveral, FL | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8210631002?gh_jid=8210631002) |
-| 🚀 SpaceX | New Graduate Engineer, Mechanical - Satellites (Starlink)  | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8407431002?gh_jid=8407431002) |
-| 🚀 SpaceX | New Graduate Engineer, Mechanical (Starlink) | Bastrop, TX | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8148516002?gh_jid=8148516002) |
-| 🚀 SpaceX | New Graduate Engineer, Mechanical (Starship) | Starbase, TX | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8143964002?gh_jid=8143964002) |
-| 🚀 SpaceX | New Graduate Engineer, Propulsion (Starship) | Starbase, TX | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8143997002?gh_jid=8143997002) |
-| 🚀 SpaceX | New Graduate Engineer, Software | Hawthorne, CA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8145483002?gh_jid=8145483002) |
-| 🚀 SpaceX | New Graduate Engineer, Software (Starlink) | Redmond, WA | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8376990002?gh_jid=8376990002) |
-| 🚀 SpaceX | Satellite Policy Associate (Starlink Regulatory Affairs) | Washington, DC | 2026-02-12 | [Apply](https://boards.greenhouse.io/spacex/jobs/8389716002?gh_jid=8389716002) |
-| Oscar Health | Associate, Provider Data Analytics | Atlanta, Georgia, United States | 2026-02-12 | [Apply](http://www.hioscar.com/careers/7561725?gh_jid=7561725) |
-| Oscar Health | Associate, Provider Data Analytics | Dallas, Texas, United States | 2026-02-12 | [Apply](http://www.hioscar.com/careers/7561728?gh_jid=7561728) |
-| Oscar Health | Associate, Provider Data Analytics | Tempe, Arizona, United States | 2026-02-12 | [Apply](http://www.hioscar.com/careers/7561687?gh_jid=7561687) |
-| Oscar Health | Associate, Provider Data Analytics | New York, New York, United States | 2026-02-12 | [Apply](http://www.hioscar.com/careers/7559181?gh_jid=7559181) |
-| 🚀 Reddit | On Campus Ambassador, India (Contractor) | Remote - India | 2026-02-09 | [Apply](https://job-boards.greenhouse.io/reddit/jobs/7090049) |
-| 🚀 Reddit | On Campus Ambassador, Philippines (Contractor) | Remote - Philippines | 2026-02-09 | [Apply](https://job-boards.greenhouse.io/reddit/jobs/7090134) |
-| 🚀 Grammarly | Early Career Program | San Francisco | 2026-01-22 | [Apply](https://job-boards.greenhouse.io/grammarly/jobs/7474047) |
-| Oscar Health | Provider Network Associate | Remote | 2026-01-20 | [Apply](http://www.hioscar.com/careers/7544848?gh_jid=7544848) |
-| Oscar Health | Associate, Network Contracting - Florida | Florida, United States | 2026-01-16 | [Apply](http://www.hioscar.com/careers/7495269?gh_jid=7495269) |
-| The Cigna Group | Claims Associate Representative | KA, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=fbe08ebf2468fb9e) |
-| Marmon Technologies India Private Limited | Graduate Engineer Trainee | KA, IN | 2 days ago | [Apply](https://in.indeed.com/viewjob?jk=a23f0f69d5241dff) |
-| Motus Consult | Junior Structural Engineer | Calgary, AB, CA | 1 day ago | [Apply](https://ca.indeed.com/viewjob?jk=64e610e32618a6a1) |
-| Westrek Geotechnical Services Ltd | Junior Geotechnical Engineer | Kamloops, BC, CA | 3 days ago | [Apply](https://ca.indeed.com/viewjob?jk=8bd6e5ee298c782c) |
-| Smiths Group | Engineer II Wet Seal System - Pre-order | MH, IN | 6 days ago | [Apply](https://in.indeed.com/viewjob?jk=f5e4ff7a4ac6f23a) |
-| Magna International | Graduate Engineer Trainee | MH, IN | 6 days ago | [Apply](https://in.indeed.com/viewjob?jk=c44889b95069d4c0) |
-| None | Graduate Engineer Trainee | TN, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=31f3eddbce5ce344) |
-| Fresenius Medical Care | Field Service Engineer Junior-Calicut | TN, IN | 2 days ago | [Apply](https://in.indeed.com/viewjob?jk=9dbb43820bb262fe) |
-| Fresenius Medical Care | Field Service Engineer Junior-Shimoga | TN, IN | 2 days ago | [Apply](https://in.indeed.com/viewjob?jk=b2869467d85df925) |
-| G7 CR Technologies | MERN Stack Developer (Fresher / Entry Level) | KA, IN | 2 days ago | [Apply](https://in.indeed.com/viewjob?jk=7abfa42fef87fadf) |
-| Full Creative | Client Services - Walk-in - 28th March, 2026 - Chennai | TN, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=a980327f1ce95ed1) |
-| Flex | Junior Engineer - ECM | TN, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=30e44f5e2a1fa65c) |
-| LEX3 Engineering | Junior Bridge Engineer | Red Deer, AB, CA | 1 day ago | [Apply](https://ca.indeed.com/viewjob?jk=6c1ae57cad548caa) |
-| Siemens | Production Engineering Specialist - (New Grad)- 1 year contract | Concord, ON, CA | 6 days ago | [Apply](https://ca.indeed.com/viewjob?jk=e4b4bd6996fc59a8) |
-| Knight Piesold Ltd. | Junior Engineer | Vancouver, BC, CA | Today | [Apply](https://ca.indeed.com/viewjob?jk=93dbddf1301ff931) |
-| Georgia-Pacific | Early Career Project Engineer | Englehart, ON, CA | 5 days ago | [Apply](https://ca.indeed.com/viewjob?jk=bd547c1af56151d4) |
-| Cenovus Energy | Student, HR Operations, Calgary (September 2026) | Calgary, AB, CA | 3 days ago | [Apply](https://ca.indeed.com/viewjob?jk=84c5c19fd8ec2fba) |
-| Indegene | Associate - Campaign Management | KA, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=ae714f5d1e9b00da) |
-| Rentokil Initial | Walk-in Interview: Field Sales Executive - Ahmedabad \| 13 March 2026 | IN | 2 days ago | [Apply](https://in.indeed.com/viewjob?jk=0c1b969cb0ebde6b) |
-| Eaton | Associate Engineer - FEA - M&S CoE - Mobility | MH, IN | 2026-01-29 | [Apply](https://in.indeed.com/viewjob?jk=5aa64019fe72582d) |
-| Artefact | Junior Data Consultant - (Canada-based) | Montréal, QC, CA | 1 day ago | [Apply](https://ca.indeed.com/viewjob?jk=8b93e56b82574997) |
-| Roche | Regulatory Affairs Associate (18 month contract) | Mississauga, ON, CA | 1 day ago | [Apply](https://ca.indeed.com/viewjob?jk=a66f8031296e6476) |
-| Amazon Web Services | Associate Data AnaIytics Consultant 🇺🇸 | Arlington, VA, US | 2026-03-04 | [Apply](https://www.indeed.com/viewjob?jk=50d0a458c3112917) |
-| Amazon Web Services | Associate Data AnaIytics Consultant 🇺🇸 | Seattle, WA, US | 2026-03-04 | [Apply](https://www.indeed.com/viewjob?jk=bf654e56b7944358) |
-| Arup | Graduate Facades Engineering (Available 2026) | Toronto, ON, CA | 1 day ago | [Apply](https://ca.indeed.com/viewjob?jk=8ea4d4fe63e977c2) |
-| PwC | September 2026 - Transfer Pricing & Customs Non-CPA - Full-time - Vancouver | Vancouver, BC, CA | 1 day ago | [Apply](https://ca.indeed.com/viewjob?jk=e606f9404a1a673b) |
-| PwC | September 2026 - Transfer Pricing & Customs Non-CPA - Full-time - Calgary | Calgary, AB, CA | 1 day ago | [Apply](https://ca.indeed.com/viewjob?jk=771254080616cb69) |
-| Narsee Monjee Institute of Management Studies | Associate Professor - Electronics and Telecommunication Engineering | MH, IN | 2026-03-05 | [Apply](https://in.indeed.com/viewjob?jk=e11590fbc72d2ac6) |
-| Narsee Monjee Institute of Management Studies | Associate Professor - Mechanical Engineering | MH, IN | 2026-03-05 | [Apply](https://in.indeed.com/viewjob?jk=776fabfa99757920) |
-| Narsee Monjee Institute of Management Studies | Associate Professor - Computer Science and Engineering (Data Science) | MH, IN | 2026-03-05 | [Apply](https://in.indeed.com/viewjob?jk=29966de29e69c5e4) |
-| Citi | Junior Java Developer | Tampa, FL, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=a1d2ea213fd04dc9) |
-| California State University | 2026-27 Lecturer Pool Department of Mechanical and Mechatronic Engineering and Advanced Manufacturing | Chico, CA, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=c9c55995508e4780) |
-| Qualitrol | Operations & Manufacturing Cooperative Education Student (Summer 2026) | Fairport, NY, US | 2 days ago | [Apply](https://www.indeed.com/viewjob?jk=cc7300b1025c86a4) |
-| Fluor Corp. | Associate Design Engineer I - New Graduate | Greenville, SC, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=0cef43fd3d8ec485) |
-| Micron Technology | New College Grad - PSE Design Validation Engineer, HBM | Richardson, TX, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=3d86f24deefe2c21) |
-| Fluor Corp. | Associate Design Engineer I - New Graduate | Greenville, SC, US | 2 days ago | [Apply](https://www.indeed.com/viewjob?jk=e18e59ae663796ca) |
-| Selkirk College | Campus Service Representative, Castlegar | Castlegar, BC, CA | 1 day ago | [Apply](https://ca.indeed.com/viewjob?jk=732f734d7940b542) |
-| PwC | September 2026 - Actuarial P&C Non-CPA - Full Time - Montreal | Montréal, QC, CA | 1 day ago | [Apply](https://ca.indeed.com/viewjob?jk=1bfa0207e9117aa8) |
-| PwC | September 2026 - Data Enablement (CPA) - Full-time - Vancouver | Vancouver, BC, CA | 3 days ago | [Apply](https://ca.indeed.com/viewjob?jk=b143e74938e8c45e) |
-| PwC | September 2026 - Data Enablement (CPA) - 8 month Co-op - Vancouver | Vancouver, BC, CA | 3 days ago | [Apply](https://ca.indeed.com/viewjob?jk=4a14b7c7ef6de27c) |
-| Venturesathi Global Inc. | Digital Community Trainee | OR, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=b6d8e2137dcd2223) |
-| CHA Consulting, Inc. | Entry Level Civil Engineer | Syracuse, NY, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=031f6923ff759c9c) |
-| GFT | Entry Level Structural Engineer | Baltimore, MD, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=5458b86e3f610939) |
-| WSP | Early Career Environmental Engineer | Portland, ME, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=46eb48661e177ff7) |
-| 🔥 Lockheed Martin | System Integration/Test Engineer Associate | Halifax, NS, CA | 1 day ago | [Apply](https://ca.indeed.com/viewjob?jk=1634ecdc5fd1b084) |
-| Nutrien | Mgr, Software Engineering | Saskatoon, SK, CA | 2026-02-19 | [Apply](https://ca.indeed.com/viewjob?jk=8936ac1f367ad3dc) |
-| 🔥 NVIDIA | Pricing Operation Specialist - New College Graduate 2026 | Santa Clara, CA, US | 2 days ago | [Apply](https://www.indeed.com/viewjob?jk=1150f50984525281) |
-| 🔥 NVIDIA | Software Development Engineer in Test, Graphics - New College Grad 2026 | Austin, TX, US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=addbe631193a5a0c) |
-| 🔥 NVIDIA | AI Inference Performance Engineer - New College Grad 2026 | Santa Clara, CA, US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=3e85f810afa2db26) |
-| Atlas Schools | SY2026-27 Elementary School CLDE Interventionist | Colorado Springs, CO, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=7b96fa8e4c61c2d9) |
-| Sentara | Registered Nurse (RN) - Emergency Department (New Grads Welcome) | Woodbridge, VA, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=3c11114c5dcd7faa) |
-| CliniSys | Associate Quality Engineer | KA, IN | 2026-02-24 | [Apply](https://in.indeed.com/viewjob?jk=e60ad0187543cd37) |
-| Breakthrough New York | Operations Assistant (Summer 2026) | New York, NY, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=20fabdb3c5bf9fe9) |
-| University of Waterloo | Professional Graduate Programs Coordinator | Waterloo, ON, CA | 1 day ago | [Apply](https://ca.indeed.com/viewjob?jk=d5c3d8c2d64b4d9d) |
-| Section23 Developments | Estimator (New Grad/Recent Graduate) | Calgary, AB, CA | 6 days ago | [Apply](https://ca.indeed.com/viewjob?jk=a85044f1fee7845b) |
-| Garden City Community College | Assistant Professor of Business (On-Campus) | Garden City, KS, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=a4b590ecbb03ee14) |
-| Matrix Design Group Inc. | Junior SharePoint & Power Apps Developer | San Antonio, TX, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=f0ff31d0115d7278) |
-| Matrix Design Group Inc. | Junior SharePoint & Power Apps Developer | Colorado Springs, CO, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=1105cf90cb566907) |
-| Matrix Design Group Inc. | Junior SharePoint & Power Apps Developer | Denver, CO, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=d138fa3d9708909c) |
-| Matrix Design Group Inc. | Junior SharePoint & Power Apps Developer | Phoenix, AZ, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=3acd976b1611a1e7) |
-| CAM Industrial Solutions | Field Engineer (New Graduate) | Saint John, NB, CA | 2 days ago | [Apply](https://ca.indeed.com/viewjob?jk=79d525cfa658ff5c) |
-| 🔥 Mastercard | Specialist - Campus Recruitment | MH, IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=b37b3dcb8b022c6f) |
-| The University of Michigan | Undergraduate Program Coordinator | Ann Arbor, MI, US | 2 days ago | [Apply](https://www.indeed.com/viewjob?jk=27902f2d74c4fda2) |
-| Fairview Park Hospital-Dublin | RN New Grad Resident ED | Dublin, GA, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=03ced46a2b9bf501) |
-| Fairview Park Hospital-Dublin | New Grad RN Resident Emergency Room | Dublin, GA, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=636fdf6beb92ab28) |
-| NCS International Co. | Management Trainee - New Graduates - Abbotsford | Abbotsford, BC, CA | 2 days ago | [Apply](https://ca.indeed.com/viewjob?jk=749a6459b82a0b8d) |
-| NCS International Co. | Management Trainee - New Graduates - Mississauga | Mississauga, ON, CA | 2 days ago | [Apply](https://ca.indeed.com/viewjob?jk=aae92b84f6f39658) |
-| Wonderbrands | Quality Continuous Improvement Program Specialist (Open to New Graduates) | Regina, SK, CA | 2026-03-05 | [Apply](https://ca.indeed.com/viewjob?jk=75df4227d2d3c669) |
-| Narsee Monjee Institute of Management Studies | Associate Professor - Computer Engineering | MH, IN | 2026-03-05 | [Apply](https://in.indeed.com/viewjob?jk=e04e4321b47c32a3) |
-| Scotiabank | 2026 Global Capital Markets Rotational Program | New York, NY, US | 3 days ago | [Apply](https://www.indeed.com/viewjob?jk=4ebfa95e91cad51e) |
-| 🔥 L3Harris | Specialist, Systems Engineering | Yorba Linda, CA, US | 2 days ago | [Apply](https://www.indeed.com/viewjob?jk=1060c979bd01df72) |
-| 🔥 L3Harris | Associate, Manufacturing Engineer (San Diego, CA) | San Diego, CA, US | 2 days ago | [Apply](https://www.indeed.com/viewjob?jk=15b3754e0aff28cf) |
-| Magnum Cementing Services | Junior Contract Administrator (New Grad) - Calgary, AB | Calgary, AB, CA | 1 day ago | [Apply](https://ca.indeed.com/viewjob?jk=3a9c0d98b5c49dd9) |
-| AAA Club Alliance | Associate Retail Travel Agent (In-Store Sales) | Phillipsburg, NJ, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=5d41610c579e058b) |
-| Mesa Public Schools - AZ | Coordinator – Multi-tiered Behavioral Supports (Elementary) - 2026-2027 | Mesa, AZ, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=67d144840e9bb258) |
-| The Out Factory | Digital Marketing Associate (AI Systems & Growth) | KA, IN | 2 days ago | [Apply](https://in.indeed.com/viewjob?jk=486af3b6e25eb6c4) |
-| Quinnipiac University | Part-Time Faculty: Nursing - Summer 2026 | North Haven, CT, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=dda2b6c019a884e7) |
-| CE Showroom Inc. | AI & eCommerce Marketing Associate | Roseville, CA, US | 6 days ago | [Apply](https://www.indeed.com/viewjob?jk=caf808d9340b9851) |
-| SUNY Brockport | 2026/2027 Adjunct Lecturer- History | Brockport, NY, US | 2 days ago | [Apply](https://www.indeed.com/viewjob?jk=8f2d8f54c86f9782) |
-| SUNY Brockport | 2026/2027 Adjunct Lecturer - Nursing | Brockport, NY, US | 2 days ago | [Apply](https://www.indeed.com/viewjob?jk=be187ee8a94b3aea) |
-| SUNY Brockport | 2026/2027 Adjunct Lecturer- Chemistry and Biochemistry | Brockport, NY, US | 2 days ago | [Apply](https://www.indeed.com/viewjob?jk=ad97fb8623db74f6) |
-| SUNY Brockport | 2026/2027 Adjunct Lecturer - Theatre and Music Studies | Brockport, NY, US | 2 days ago | [Apply](https://www.indeed.com/viewjob?jk=b52d61f62ca0e48f) |
-| SUNY Brockport | 2026/2027 Adjunct Lecturer - Criminal Justice | Brockport, NY, US | 2 days ago | [Apply](https://www.indeed.com/viewjob?jk=485fd5d6fd924a0b) |
-| SUNY Brockport | 2026/2027 Adjunct Lecturer - Mathematics | Brockport, NY, US | 2 days ago | [Apply](https://www.indeed.com/viewjob?jk=e8425285a4531505) |
-| SUNY Brockport | 2026/2027 Adjunct Lecturer - Kinesiology, Sport Studies & Physical Education (KSSPE) | Brockport, NY, US | 2 days ago | [Apply](https://www.indeed.com/viewjob?jk=ce3b5f40cc50d229) |
-| Action Behavior Centers - ABA Therapy for Autism | ABA Student Analyst, Field Work, Graduate Program | Charlotte, NC, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=1b8699236f24dc5b) |
-| Action Behavior Centers - ABA Therapy for Autism | ABA Student Analyst, Field Work, Graduate Program | Beaumont, TX, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=471641c725118cc9) |
-| Action Behavior Centers - ABA Therapy for Autism | ABA Student Analyst, Field Work, Graduate Program | College Station, TX, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=fec299e3e430cd82) |
-| Action Behavior Centers - ABA Therapy for Autism | ABA Student Analyst, Field Work, Graduate Program | Waco, TX, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=577fbe747adc927a) |
-| Action Behavior Centers - ABA Therapy for Autism | ABA Student Analyst, Field Work, Graduate Program | Lubbock, TX, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=f2712b1cb785f6ca) |
-| Action Behavior Centers - ABA Therapy for Autism | ABA Student Analyst, Field Work, Graduate Program | Raleigh, NC, US | 2 days ago | [Apply](https://www.indeed.com/viewjob?jk=97bbded7c5092d50) |
-| Action Behavior Centers - ABA Therapy for Autism | ABA Student Analyst, Field Work, Graduate Program *Relocating Assistance | US | 2 days ago | [Apply](https://www.indeed.com/viewjob?jk=dfe63df4ddeae483) |
-| Action Behavior Centers - ABA Therapy for Autism | ABA Student Analyst, Field Work, Graduate Program | Dallas, TX, US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=4aff85a6eb37efaa) |
-| Action Behavior Centers - ABA Therapy for Autism | ABA Student Analyst, Field Work, Graduate Program | Dallas, TX, US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=fc0959f04ac557ed) |
-| Action Behavior Centers - ABA Therapy for Autism | ABA Student Analyst, Field Work, Graduate Program | Minneapolis, MN, US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=0143b9016402141d) |
-| Action Behavior Centers - ABA Therapy for Autism | ABA Student Analyst, Field Work, Graduate Program | Minneapolis, MN, US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=4711a2bd46d74a5a) |
-| Action Behavior Centers - ABA Therapy for Autism | ABA Student Analyst, Field Work, Graduate Program | Denver, CO, US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=67948a579e4cbf33) |
-| Action Behavior Centers - ABA Therapy for Autism | ABA Student Analyst, Field Work, Graduate Program | Tucson, AZ, US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=7561ee20812bcfc4) |
-| Action Behavior Centers - ABA Therapy for Autism | ABA Student Analyst, Field Work, Graduate Program | Phoenix, AZ, US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=8ed6601b339742b8) |
-| Action Behavior Centers - ABA Therapy for Autism | ABA Student Analyst, Field Work, Graduate Program | San Antonio, TX, US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=69fa0d4a99218ca2) |
-| Action Behavior Centers - ABA Therapy for Autism | ABA Student Analyst, Field Work, Graduate Program | Austin, TX, US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=49409f793256e1cc) |
-| Aon | Early Careers Actuary - Reinsurance | Chicago, IL, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=3338d85d5788df7d) |
-| The Walt Disney Company | Decision Science Graduate Associate, Summer/Fall 2026 | Lake Buena Vista, FL, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=31c6802325a5b972) |
-| Deloitte | Consultant - Data & Analytics, Assurance - New Grad 2027 - Vancouver | Vancouver, BC, CA | 2026-02-25 | [Apply](https://ca.indeed.com/viewjob?jk=3764f34e9b46e167) |
-| Los Angeles Community Hospitals | New Grad RN (Med Surg) - 11157 - Loan Forgiveness - Full Time, Days (East Los Angeles) | Los Angeles, CA, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=513266fe48a0d9d7) |
-| PIH Health | New Grad Registered Nurse (RN), PIH Health Whittier Hospital, May 18, 2026 Cohort | Whittier, CA, US | 3 days ago | [Apply](https://www.indeed.com/viewjob?jk=c411011128b0152a) |
-| Veloris Global | Business Development Trainee | KL, IN | 2 days ago | [Apply](https://in.indeed.com/viewjob?jk=6e49fb54e3b2aca5) |
-| Boston Scientific | R&D Engineering Fall/Winter Co-op 2026 | Austin, TX, US | 6 days ago | [Apply](https://www.indeed.com/viewjob?jk=6857071710685319) |
-| Vertex Pharmaceuticals | Vertex Fall Co-op 2026, Data Technology & Engineering for Research | Boston, MA, US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=ea25293655a222c8) |
-| Vertex Pharmaceuticals | Vertex Fall Co-op 2026, Gene Editing Research | Boston, MA, US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=7fbff2f50983f6e5) |
-| Vertex Pharmaceuticals | Vertex Fall Co-op 2026, Global Logistics | Boston, MA, US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=0afd9b9cff0c01d6) |
-| Vertex Pharmaceuticals | Vertex Fall Co-op 2026, Operational Excellence, Vertex Manufacturing Center (VMC) | Boston, MA, US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=e37bc39ba9ca8163) |
-| Vertex Pharmaceuticals | Vertex Fall Co-op 2026, Global Supply Chain, Risk Management | Boston, MA, US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=e83fe50ccda8fc59) |
-| HRI Hospital | Registered Nurse (RN) - New Graduate | Brookline, MA, US | 1 day ago | [Apply](https://www.indeed.com/viewjob?jk=29109431dddca18c) |
-| Pembroke Hospital | Registered Nurse (RN) - New Graduate | Pembroke, MA, US | 5 days ago | [Apply](https://www.indeed.com/viewjob?jk=83610cf374ddf370) |
-| Fuller Hospital | Registered Nurse (RN) - New Graduate | South Attleboro, MA, US | 5 days ago | [Apply](https://www.indeed.com/viewjob?jk=c3584970e164ed51) |
-| Pembroke Hospital | Registered Nurse (RN) - New Graduate | Pembroke, MA, US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=53046d856bc1e0ea) |
-| Fuller Hospital | Registered Nurse (RN) - New Graduate (+$10,000 Sign) | Attleboro, MA, US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=1c03469d5b503303) |
-| Wipro | GenAI Developer (Entry Level) | Charlotte, NC, US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=0c4ce053fda84041) |
-| Wipro | Test Automation Developer (Entry Level) | Detroit, MI, US | 2026-03-05 | [Apply](https://www.indeed.com/viewjob?jk=3fd36204820da354) |
-| SAP | Business Processes Associate Consultant- SAP Basis Upgrade-T1-Bangalore/Mumbai | MH, IN | 2026-03-05 | [Apply](https://in.indeed.com/viewjob?jk=3acc9250b95893d8) |
-| AMC Bridge | C++ Software Development Engineer (Trainee) | IN | 1 day ago | [Apply](https://in.indeed.com/viewjob?jk=c1a4dda36bfcb13e) |
-| 🔥 Mastercard | Specialist - Campus Recruitment | Pune, India | Today | [Apply](https://mastercard.wd1.myworkdayjobs.com/job/Pune-India/Specialist---Campus-Recruitment_R-272503-1) |
-| 🔥 NVIDIA | Pricing Operation Specialist - New College Graduate 2026 | US, CA, Santa Clara | 1 day ago | [Apply](https://nvidia.wd5.myworkdayjobs.com/job/US-CA-Santa-Clara/Pricing-Operation-Specialist---New-College-Graduate-2026_JR2014380) |
-| 🔥 Intel | Verification Engineer (Junior) | Virtual Canada | 5 days ago | [Apply](https://intel.wd1.myworkdayjobs.com/job/Virtual-Canada/Verification-Engineer--Junior-_JR0281618) |
-| Citi | Client - Citi Research, Global Strategy & Macro Group, Summer Analyst, New York City - US 2026 | New York New York United States | Today | [Apply](https://citi.wd5.myworkdayjobs.com/job/New-York-New-York-United-States/Client---Citi-Research--Global-Strategy---Macro-Group--Summer-Analyst--New-York-City---US-2026_25838553) |
-| Citi | Junior Java Developer | Tampa Florida United States | Today | [Apply](https://citi.wd5.myworkdayjobs.com/job/Tampa-Florida-United-States/Junior-Java-Developer_26941825-1) |
-| Medtronic | Quality Engineer II - 2nd Shift | Grand Rapids, Michigan, United States of America | 1 day ago | [Apply](https://medtronic.wd1.myworkdayjobs.com/job/Grand-Rapids-Michigan-United-States-of-America/Quality-Engineer-II---2nd-Shift_R59658-1) |
-| Medtronic | Advanced Manufacturing Engineer II – Equipment | Danvers, Massachusetts, United States of America | 2 days ago | [Apply](https://medtronic.wd1.myworkdayjobs.com/job/Danvers-Massachusetts-United-States-of-America/Advanced-Manufacturing-Engineer-II---Equipment_R61274-1) |
-| Walmart | (CAN) Dairy Frozen Associate | Victoria, BC | 2026-03-05 | [Apply](https://walmart.wd5.myworkdayjobs.com/job/Victoria-BC/XMLNAME--CAN--Dairy-Frozen-Associate_R-2436292) |
-| Walmart | (USA) Coach/Ops Mgr Trainee | (USA) WA MONROE 05628 WM SUPERCENTER | 2026-03-01 | [Apply](https://walmart.wd5.myworkdayjobs.com/job/USA-WA-MONROE-05628-WM-SUPERCENTER/XMLNAME--USA--Coach-Ops-Mgr-Trainee_R-2427672-1) |
-| Walmart | (USA) Coach/Ops Mgr Trainee | Natchez, MS | 2026-02-28 | [Apply](https://walmart.wd5.myworkdayjobs.com/job/Natchez-MS/XMLNAME--USA--Coach-Ops-Mgr-Trainee_R-2427892-1) |
-| Walmart | (USA) Coach/Ops Mgr Trainee | Evergreen, CO | 2026-02-10 | [Apply](https://walmart.wd5.myworkdayjobs.com/job/Evergreen-CO/XMLNAME--USA--Coach-Ops-Mgr-Trainee_R-2409261-1) |
-| Walmart | (USA) Coach/Ops Mgr Trainee | Prattville, AL | Today | [Apply](https://walmart.wd5.myworkdayjobs.com/job/Prattville-AL/XMLNAME--USA--Coach-Ops-Mgr-Trainee_R-2414173-1) |
-| 🔥 Northrop Grumman | Associate Manufacturing Engineer | United States-California-Palmdale | Today | [Apply](https://ngc.wd1.myworkdayjobs.com/job/United-States-California-Palmdale/Associate-Manufacturing-Engineer_R10225382) |
-| 🔥 Northrop Grumman | Associate Engineer Tool | United States-California-El Segundo | Today | [Apply](https://ngc.wd1.myworkdayjobs.com/job/United-States-California-El-Segundo/Associate-Engineer-Tool_R10225330) |
-| 🔥 Northrop Grumman | Engineer Information Assurance - Level 1 | United States-California-Redondo Beach | Today | [Apply](https://ngc.wd1.myworkdayjobs.com/job/United-States-California-Redondo-Beach/Engineer-Information-Assurance---Level-1_R10225561) |
-| 🔥 Northrop Grumman | Integration & Test Engineer Level 2/3 | United States-Illinois-Rolling Meadows | 1 day ago | [Apply](https://ngc.wd1.myworkdayjobs.com/job/United-States-Illinois-Rolling-Meadows/Integration---Test-Engineer-Level-2-3_R10225201) |
-| 🔥 Northrop Grumman | Associate Engineer Tool Design | United States-California-El Segundo | 1 day ago | [Apply](https://ngc.wd1.myworkdayjobs.com/job/United-States-California-El-Segundo/Associate-Engineer-Tool-Design_R10225331) |
-| 🔥 Northrop Grumman | Associate Engineer Systems/Engineer Systems | United States-Alabama-Huntsville | 1 day ago | [Apply](https://ngc.wd1.myworkdayjobs.com/job/United-States-Alabama-Huntsville/Associate-Engineer-Systems-Engineer-Systems_R10225451-1) |
-| 🔥 Northrop Grumman | Engineering Technician Level 2 or 3 (Active Secret Clearance Required) 🇺🇸 | United States-California-San Diego | 1 day ago | [Apply](https://ngc.wd1.myworkdayjobs.com/job/United-States-California-San-Diego/Engineering-Technician-Level-2-or-3--Active-Secret-Clearance-Required-_R10225480) |
-| 🔥 Boeing | Associate Quality Engineer | IND - Bangalore, India | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/IND---Bangalore-India/Associate-Quality-Engineer_JR2026498529-1) |
-| 🔥 Boeing | Structure & Payload Design Engineer (Associate and Mid-Level) | USA - Oklahoma City, OK | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---Oklahoma-City-OK/Structure---Payload-Design-Engineer--Associate-and-Mid-Level-_JR2026499703-2) |
-| 🔥 Boeing | Guidance Navigation & Control Engineer (Associate) | USA - Long Beach, CA | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---Long-Beach-CA/Guidance-Navigation---Control-Engineer--Associate-_JR2026500010-1) |
-| 🔥 Boeing | Payloads Design Engineer (Associate or Experienced) (Mechanical/Structural) | USA - North Charleston, SC | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---North-Charleston-SC/Associate-Payloads-Design-Engineer--Mechanical-Structural-_JR2026498544-1) |
-| 🔥 Boeing | P-8 Wire Design & Install Design Engineer (Associate or Mid-Level) | USA - Jacksonville, FL | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---Jacksonville-FL/P-8-Wire-Design---Install-Design-Engineer--Associate-or-Mid-Level-_JR2026500309-1) |
-| 🔥 Boeing | Structures & Payload Design Engineer (Structural Design), Associate & Mid-Level | USA - Mesa, AZ | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---Mesa-AZ/Structures---Payload-Design-Engineer--Structural-Design---Associate---Mid-Level_JR2026498178) |
-| 🔥 Boeing | Propulsion System Integration Engineers (Associate or Mid-Level) | USA - North Charleston, SC | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---North-Charleston-SC/Propulsion-System-Integration-Engineers--Associate-or-Mid-Level-_JR2026499167-1) |
-| 🔥 Boeing | Associate Product Data Specialist | USA - Berkeley, MO | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---Berkeley-MO/Associate-Product-Data-Specialist_JR2026499590) |
-| 🔥 Boeing | Associate Electrical Design Engineer | USA - Seal Beach, CA | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---Seal-Beach-CA/Associate-Electrical-Design-Engineer_JR2026498224-2) |
-| 🔥 Boeing | Fuel Systems Service Engineer (Associate or Experienced) (Propulsion Analysis - Air) | USA - Seal Beach, CA | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---Seal-Beach-CA/Fuel-Systems-Service-Engineer--Associate-or-Experienced---Propulsion-Analysis---Air-_JR2026497047-1) |
-| 🔥 Boeing | Associate Quality Engineer | USA - Berkeley, MO | Today | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---Berkeley-MO/Associate-Quality-Engineer_JR2026495611-1) |
-| 🔥 Boeing | Entry Level Supply Chain Specialist - Repairs Management | USA - Dallas, TX | 1 day ago | [Apply](https://boeing.wd1.myworkdayjobs.com/job/USA---Dallas-TX/Entry-Level-Supply-Chain-Specialist---Repairs-Management_JR2026499341-2) |
+| Precision Medicine Group | Clinical Data Associate II | Bangalore, Karnataka, India | Today | [Apply](https://job-boards.greenhouse.io/precisionmedicinegroup/jobs/6115218004) |
+| 🚀 SoFi | Associate AI Financial Planning Analyst | New York City | Today | [Apply](https://sofi.com/careers/job/7781335003?gh_jid=7781335003) |
+| 🚀 SpaceX | December 2026 New Graduate Engineer, Mechanical (Starship) | Starbase, TX | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8627507002?gh_jid=8627507002) |
+| 🚀 SpaceX | December 2026 New Graduate Engineer, Propulsion (Starship) | Starbase, TX | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8627510002?gh_jid=8627510002) |
+| 🚀 SpaceX | Machine Maintenance Associate (Starlink) | Bastrop, TX | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8420866002?gh_jid=8420866002) |
+| 🚀 SpaceX | NDE Inspector Trainee (Starship) - Temporary | Starbase, TX | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8428315002?gh_jid=8428315002) |
+| 🚀 SpaceX | NDE Inspector Trainee (Starship) - Temporary (Radiography) | Starbase, TX | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8578887002?gh_jid=8578887002) |
+| 🚀 SpaceX | New Graduate Engineer, Mechanical (Cape Canaveral) | Cape Canaveral, FL | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8622574002?gh_jid=8622574002) |
+| 🚀 SpaceX | New Graduate Engineer, Mechanical (Starlink) | Redmond, WA | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8542046002?gh_jid=8542046002) |
+| 🚀 SpaceX | New Graduate Engineer, Mechanical (Starship) | Starbase, TX | Today | [Apply](https://boards.greenhouse.io/spacex/jobs/8497499002?gh_jid=8497499002) |
 
+**[→ View all 153 Other roles on the live board](https://jobs.riteshrana.engineer/)**
+
+<!-- CATEGORY-LISTINGS:END -->
 ---
 
 ## 📊 About This Repository

--- a/scripts/sync_readme_jobs.py
+++ b/scripts/sync_readme_jobs.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Regenerate the per-category job tables in README.md from docs/jobs.json.
+
+The README's "Browse by Category" listings used to be a frozen, hand-maintained
+snapshot that rotted (dead links, missing new roles) while the site refreshed
+every 5 minutes. This module keeps them live: it rewrites *only* the block
+between::
+
+    <!-- CATEGORY-LISTINGS:START ... -->
+    <!-- CATEGORY-LISTINGS:END -->
+
+with, for each category, the ``TOP_N`` most recently posted **open** roles plus
+a link to the live board for the complete, filterable list. Everything outside
+the markers (badges, legend, About, contributing, …) is untouched.
+
+Category order/names/emojis are read from ``docs/jobs.json`` ``meta.categories``
+so this file never drifts from the scraper's taxonomy. Invoked from
+scripts/update_jobs.py after each scrape; also safe to run by hand::
+
+    python scripts/sync_readme_jobs.py
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+from typing import Any, Dict, List
+
+TOP_N = 10
+LIVE_BOARD_URL = "https://jobs.riteshrana.engineer/"
+
+# Presentation order for the README sections. The scraper's CATEGORY_PATTERNS is
+# ordered for *matching precedence* (specialties first); this is the reader-facing
+# order and matches the "Browse by Category" nav and the site's filter chips:
+# the broad Software Engineering bucket leads, then its specialties, then the
+# remaining disciplines.
+PRESENTATION_ORDER = [
+    "software_engineering",
+    "frontend",
+    "backend",
+    "mobile",
+    "security",
+    "data_ml",
+    "data_engineering",
+    "infrastructure_sre",
+    "product_management",
+    "quant_finance",
+    "hardware",
+    "other",
+]
+
+START_MARKER = (
+    "<!-- CATEGORY-LISTINGS:START - auto-generated from docs/jobs.json by "
+    "scripts/sync_readme_jobs.py; do not edit by hand -->"
+)
+END_MARKER = "<!-- CATEGORY-LISTINGS:END -->"
+
+_BLOCK_RE = re.compile(
+    re.escape("<!-- CATEGORY-LISTINGS:START") + r".*?" + re.escape(END_MARKER),
+    re.DOTALL,
+)
+
+
+def _cell(value: str) -> str:
+    """Sanitize a value for a Markdown table cell (no pipes/newlines)."""
+    return " ".join(str(value or "—").replace("|", "/").split()).strip() or "—"
+
+
+def _company(job: Dict[str, Any]) -> str:
+    emoji = (job.get("company_tier") or {}).get("emoji", "") or ""
+    name = _cell(job.get("company", "—"))
+    return f"{emoji} {name}".strip()
+
+
+def _sort_key(job: Dict[str, Any]):
+    # Most-recent first: ISO posted_at sorts chronologically; blanks sort last.
+    return job.get("posted_at") or ""
+
+
+def _recent_open_jobs(jobs: List[Dict[str, Any]], category_id: str, limit: int) -> List[Dict[str, Any]]:
+    in_cat = [
+        j
+        for j in jobs
+        if (j.get("category") or {}).get("id") == category_id and not j.get("is_closed")
+    ]
+    in_cat.sort(key=_sort_key, reverse=True)
+    return in_cat[:limit]
+
+
+def _render_table(rows: List[Dict[str, Any]]) -> str:
+    lines = [
+        "| Company | Role | Location | Posted | Apply |",
+        "|---------|------|----------|--------|-------|",
+    ]
+    for job in rows:
+        posted = _cell(job.get("posted_display") or (job.get("posted_at") or "")[:10])
+        url = (job.get("url") or "").strip()
+        apply_cell = f"[Apply]({url})" if url else "—"
+        lines.append(
+            f"| {_company(job)} | {_cell(job.get('title', '—'))} "
+            f"| {_cell(job.get('location', '—'))} | {posted} | {apply_cell} |"
+        )
+    return "\n".join(lines)
+
+
+def render_category_listings(data: Dict[str, Any]) -> str:
+    """Return the full auto-generated block (markers included)."""
+    jobs = data.get("jobs", []) or []
+    meta = data.get("meta", {}) or {}
+    categories = meta.get("categories", []) or []
+    total = meta.get("total_jobs", len(jobs))
+
+    # Present in reader-facing order; unknown ids keep their meta order at the end.
+    order = {cid: i for i, cid in enumerate(PRESENTATION_ORDER)}
+    categories = sorted(categories, key=lambda c: order.get(c.get("id"), len(order)))
+
+    parts: List[str] = [
+        START_MARKER,
+        "",
+        f"> 📋 **Live listings** — the {TOP_N} most recently posted roles per "
+        f"category, refreshed every 5 minutes. Browse and filter all "
+        f"**{total:,}** live roles on the **[live job board]({LIVE_BOARD_URL})**.",
+        "",
+    ]
+
+    for cat in categories:
+        cid = cat.get("id")
+        name = cat.get("name", cid)
+        emoji = cat.get("emoji", "")
+        count = cat.get("count", 0)
+        rows = _recent_open_jobs(jobs, cid, TOP_N)
+
+        parts.append(f"## {emoji} {name} New Grad Roles".strip())
+        parts.append("")
+        parts.append("[Back to top](#-2026-new-grad-positions)")
+        parts.append("")
+        if rows:
+            parts.append(_render_table(rows))
+            parts.append("")
+            if count > len(rows):
+                parts.append(
+                    f"**[→ View all {count:,} {name} roles on the live board]"
+                    f"({LIVE_BOARD_URL})**"
+                )
+                parts.append("")
+        else:
+            parts.append("_No open roles in this category right now — "
+                         f"check the [live board]({LIVE_BOARD_URL})._")
+            parts.append("")
+
+    parts.append(END_MARKER)
+    return "\n".join(parts)
+
+
+def sync_readme_jobs(repo_root: pathlib.Path | str = ".") -> bool:
+    """Rewrite the category-listings block in README.md. Returns True if written."""
+    repo_root = pathlib.Path(repo_root)
+    readme_path = repo_root / "README.md"
+    jobs_path = repo_root / "docs" / "jobs.json"
+
+    readme = readme_path.read_text(encoding="utf-8")
+    if not _BLOCK_RE.search(readme):
+        print("sync_readme_jobs: CATEGORY-LISTINGS markers not found; skipping.")
+        return False
+
+    with open(jobs_path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    new_block = render_category_listings(data)
+    updated = _BLOCK_RE.sub(lambda _m: new_block, readme, count=1)
+    if updated == readme:
+        print("sync_readme_jobs: README.md already up to date.")
+        return False
+    readme_path.write_text(updated, encoding="utf-8")
+    print("sync_readme_jobs: updated README.md category listings")
+    return True
+
+
+if __name__ == "__main__":
+    import sys
+
+    root = sys.argv[1] if len(sys.argv) > 1 else "."
+    sync_readme_jobs(root)

--- a/scripts/update_jobs.py
+++ b/scripts/update_jobs.py
@@ -3501,16 +3501,22 @@ def main():
                          url_blocked_count=url_blocked_count)
 
     # ========== Sync README count tokens ==========
-    # README.md remains a hand-edited document; only the digits inside
-    # <!-- COUNT:<id> -->…<!-- /COUNT --> markers are rewritten to match
-    # docs/jobs.json. See scripts/sync_readme_counts.py and
-    # tests/test_readme_sync.py for the contract.
+    # README.md is hand-edited *except* two auto-managed regions:
+    #   1. the <!-- COUNT:<id> --> digits + "Last updated" line (sync_readme_counts)
+    #   2. the <!-- CATEGORY-LISTINGS --> block of live per-category job tables
+    #      (sync_readme_jobs) — the top-N most recent open roles per category,
+    #      kept fresh so the README stops rotting relative to the live board.
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
     try:
         from sync_readme_counts import sync_readme_counts
-        repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
         sync_readme_counts(repo_root)
     except Exception as e:
         print(f"⚠️  README count sync skipped: {e}")
+    try:
+        from sync_readme_jobs import sync_readme_jobs
+        sync_readme_jobs(repo_root)
+    except Exception as e:
+        print(f"⚠️  README job-table sync skipped: {e}")
 
     # Report execution time
     elapsed = time.time() - start_time

--- a/tests/test_readme_jobs_sync.py
+++ b/tests/test_readme_jobs_sync.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Tests for the live README category-table generator (scripts/sync_readme_jobs.py)."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from sync_readme_jobs import (  # noqa: E402
+    END_MARKER,
+    START_MARKER,
+    TOP_N,
+    render_category_listings,
+    sync_readme_jobs,
+)
+
+
+def _job(cid, title, posted_at, company="Acme", closed=False, url="https://x.co/1", tier=None):
+    return {
+        "company": company,
+        "title": title,
+        "location": "Remote",
+        "url": url,
+        "posted_at": posted_at,
+        "posted_display": posted_at[:10] if posted_at else "",
+        "is_closed": closed,
+        "category": {"id": cid},
+        "company_tier": {"emoji": tier} if tier else {},
+    }
+
+
+def _data(jobs, categories):
+    return {"jobs": jobs, "meta": {"total_jobs": len(jobs), "categories": categories}}
+
+
+def test_block_has_markers_and_headings():
+    data = _data(
+        [_job("software_engineering", "SWE", "2026-07-10")],
+        [{"id": "software_engineering", "name": "Software Engineering", "emoji": "💻", "count": 1}],
+    )
+    block = render_category_listings(data)
+    assert block.startswith(START_MARKER)
+    assert block.rstrip().endswith(END_MARKER)
+    assert "## 💻 Software Engineering New Grad Roles" in block
+    assert "[Back to top](#-2026-new-grad-positions)" in block
+    assert "| Company | Role | Location | Posted | Apply |" in block
+
+
+def test_top_n_cap_and_recency_sort():
+    jobs = [_job("software_engineering", f"Role {i}", f"2026-07-{i:02d}") for i in range(1, 21)]
+    data = _data(jobs, [{"id": "software_engineering", "name": "Software Engineering", "emoji": "💻", "count": 20}])
+    block = render_category_listings(data)
+    apply_rows = [ln for ln in block.splitlines() if "[Apply]" in ln]
+    assert len(apply_rows) == TOP_N
+    # newest first: Role 20 present, Role 1 (oldest) not among the top 10
+    assert "Role 20" in block and "Role 19" in block
+    assert "Role 01" not in block
+
+
+def test_closed_jobs_excluded():
+    jobs = [
+        _job("security", "Open Sec Role", "2026-07-10", closed=False),
+        _job("security", "Closed Sec Role", "2026-07-11", closed=True),
+    ]
+    data = _data(jobs, [{"id": "security", "name": "Security Engineering", "emoji": "🔒", "count": 1}])
+    block = render_category_listings(data)
+    assert "Open Sec Role" in block
+    assert "Closed Sec Role" not in block
+
+
+def test_view_all_link_only_when_more_than_shown():
+    many = [_job("software_engineering", f"R{i}", f"2026-07-{i:02d}") for i in range(1, 16)]
+    data = _data(many, [{"id": "software_engineering", "name": "Software Engineering", "emoji": "💻", "count": 15}])
+    assert "View all 15 Software Engineering roles" in render_category_listings(data)
+
+    few = [_job("quant_finance", "Quant", "2026-07-10")]
+    data2 = _data(few, [{"id": "quant_finance", "name": "Quantitative Finance", "emoji": "📈", "count": 1}])
+    assert "View all" not in render_category_listings(data2)
+
+
+def test_pipe_in_title_is_sanitized():
+    data = _data(
+        [_job("other", "Analyst | Ops | Team", "2026-07-10")],
+        [{"id": "other", "name": "Other", "emoji": "💼", "count": 1}],
+    )
+    block = render_category_listings(data)
+    row = [ln for ln in block.splitlines() if "Analyst" in ln][0]
+    # exactly 5 columns => 6 pipe separators; the title's pipes were replaced
+    assert row.count("|") == 6
+    assert "Analyst / Ops / Team" in row
+
+
+def test_presentation_order_software_engineering_first():
+    cats = [
+        {"id": "security", "name": "Security Engineering", "emoji": "🔒", "count": 1},
+        {"id": "software_engineering", "name": "Software Engineering", "emoji": "💻", "count": 1},
+    ]
+    jobs = [_job("security", "S", "2026-07-10"), _job("software_engineering", "E", "2026-07-10")]
+    block = render_category_listings(_data(jobs, cats))
+    assert block.index("Software Engineering New Grad") < block.index("Security Engineering New Grad")
+
+
+def test_sync_rewrites_only_the_marked_block(tmp_path):
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        f"# Title\n\nKeep me.\n\n{START_MARKER}\nOLD\n{END_MARKER}\n\n## Footer\nKeep me too.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "docs").mkdir()
+    import json
+
+    (tmp_path / "docs" / "jobs.json").write_text(
+        json.dumps(_data(
+            [_job("other", "Role A", "2026-07-10")],
+            [{"id": "other", "name": "Other", "emoji": "💼", "count": 1}],
+        )),
+        encoding="utf-8",
+    )
+    assert sync_readme_jobs(tmp_path) is True
+    out = readme.read_text(encoding="utf-8")
+    assert "Keep me." in out and "Keep me too." in out and "## Footer" in out
+    assert "OLD" not in out
+    assert "Role A" in out


### PR DESCRIPTION
## Problem

The README's per-category job tables were a **frozen, hand-maintained snapshot** while the site refreshed every 5 minutes. Measured against live data before this PR:
- **80%** of the README's ~1090 listed jobs were **dead/expired links**
- **85%** of current live roles weren't in the README at all
- The bot only rewrote the category *counts* + timestamp each scrape — never the tables.

## Fix

The pipeline now regenerates the tables every scrape (decision: **top 10 most-recently-posted open roles per category**, with **"view all N →" links to the live board**, and a professional revamp of the section).

- **`scripts/sync_readme_jobs.py`** (new): rewrites *only* the `<!-- CATEGORY-LISTINGS -->` block. Top-10 most-recent **open** roles per category, in reader-facing presentation order (matching the Browse nav + the site's filter chips), each section linking to the live board for the full list. Reads `meta.categories` so it never drifts from the scraper taxonomy; idempotent (no spurious diffs).
- **`update_jobs.py`**: runs it after each scrape, next to `sync_readme_counts`.
- **README.md**: listings region wrapped in markers + regenerated — now **100% live links, 0 dead**, and the file shrinks from ~1360 to ~400 lines.
- **tests**: `test_readme_jobs_sync.py` (top-N cap, recency sort, closed-job exclusion, pipe sanitization, presentation order, marked-block-only rewrite).

## Verification
- Regenerated block: 106 job links, **100% still live (0 dead)** vs 80% dead before.
- Idempotent: a second run is a no-op.
- Everything outside the markers (badges, legend, About, contributing) is byte-for-byte untouched.
- Full suite green (817 tests); pre-commit clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s job listings with refreshed, recently posted open roles across categories.
  * Added links to view all available roles on the live job board.
  * Replaced lengthy manually maintained tables with concise, regularly refreshed listings.

* **Chores**
  * Automated README job-listing updates while preserving surrounding documentation content.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->