### PR TITLE
fix: sync site contributor list — Nam0101 was missing from docs/contributors.json

### DIFF
--- a/docs/contributors.json
+++ b/docs/contributors.json
@@ -264,6 +264,17 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "Nam0101",
+      "name": "Nguyen Van Nam",
+      "avatar_url": "https://avatars.githubusercontent.com/u/84635991?v=4",
+      "profile": "https://github.com/Nam0101",
+      "contributions": [
+        "code",
+        "test",
+        "security"
+      ]
     }
   ],
   "generatedAt": "2026-05-26T19:05:00Z"

--- a/tests/test_contributors_sync.py
+++ b/tests/test_contributors_sync.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Guard: the site's contributor list must match the all-contributors source.
+
+The live contributors view (docs/terminal/*) reads ``docs/contributors.json``,
+which is a mirror of the ``contributors`` array in ``.all-contributorsrc`` (the
+file the all-contributors workflow updates, and which drives ``CONTRIBUTORS.md``).
+These two drifted once — a contributor added to ``.all-contributorsrc`` was
+missing from the site — so this test keeps them in lockstep.
+"""
+
+import json
+import os
+
+_REPO = os.path.join(os.path.dirname(__file__), "..")
+
+
+def _load(*parts):
+    with open(os.path.join(_REPO, *parts), encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_site_contributors_match_all_contributorsrc():
+    arc = _load(".all-contributorsrc")["contributors"]
+    site = _load("docs", "contributors.json")["contributors"]
+
+    arc_logins = [c["login"] for c in arc]
+    site_logins = [c["login"] for c in site]
+    missing_on_site = set(arc_logins) - set(site_logins)
+    extra_on_site = set(site_logins) - set(arc_logins)
+
+    assert not missing_on_site, (
+        f"contributors in .all-contributorsrc but missing from "
+        f"docs/contributors.json: {sorted(missing_on_site)}"
+    )
+    assert not extra_on_site, (
+        f"contributors on the site but not in .all-contributorsrc: "
+        f"{sorted(extra_on_site)}"
+    )
+    # Full parity (order + fields) so the site never shows a stale roster.
+    assert site == arc
+
+
+def test_contributors_json_is_wellformed():
+    site = _load("docs", "contributors.json")["contributors"]
+    assert site, "docs/contributors.json has no contributors"
+    for c in site:
+        assert {"login", "name", "avatar_url", "profile", "contributions"} <= set(c)
+        assert c["contributions"], f"{c['login']} has no contributions"


### PR DESCRIPTION
## Problem

While verifying the live **contributors** view, I found it renders correctly (26 contributors, faceted dashboard, no errors) **but is missing Nam0101** — who has 6 merged PRs and was added to `.all-contributorsrc` + `CONTRIBUTORS.md` in #338.

Root cause: the site (`docs/terminal/contributors-data.jsx`) reads **`docs/contributors.json`**, a separate mirror of `.all-contributorsrc`. #338 updated `.all-contributorsrc`/`CONTRIBUTORS.md` but not this mirror, so the two drifted (27 vs 26 entries; only difference was Nam0101).

## Fix

- Add Nam0101's entry to `docs/contributors.json` — it now matches `.all-contributorsrc` exactly (27 entries, same order/fields).
- Add `tests/test_contributors_sync.py` asserting `docs/contributors.json` ≡ `.all-contributorsrc` contributors, so this can't silently drift again.

## Verification
- `docs/contributors.json` is valid JSON and byte-parity with `.all-contributorsrc`.
- New tests pass; pre-commit clean.
- After merge + deploy I'll confirm the live view shows 27 contributors including Nam0101.