### PR TITLE
feat(frontend): make terminal site mobile-friendly (single-column reflow)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -27,6 +27,13 @@
     body { overflow-x: auto; }
     * { box-sizing: border-box; }
     #root { height: 100%; width: 100%; min-width: 1180px; }
+    /* Mobile: drop the desktop 1180px canvas so the single-column reflow
+       (driven by useIsMobile in the terminal views) fits the viewport with
+       no sideways scroll. Breakpoint mirrors MOBILE_MAX_PX in use-viewport.jsx. */
+    @media (max-width: 760px) {
+      body { overflow-x: hidden; }
+      #root { min-width: 0; }
+    }
     ::-webkit-scrollbar { width: 8px; height: 8px; }
     ::-webkit-scrollbar-track { background: #0a0a0a; }
     ::-webkit-scrollbar-thumb { background: #2a2a2a; }
@@ -61,15 +68,17 @@
   </div>
 
   <!-- Pure-JS helper for the LIVE chip, loadable in Node for unit testing. -->
-  <script src="terminal/live-stamp-format.js?v=18"></script>
+  <script src="terminal/live-stamp-format.js?v=19"></script>
 
   <!-- Cache-bust the bundle when its shape changes. Bump v= on data-shape edits. -->
-  <script type="text/babel" src="terminal/data.jsx?v=18"></script>
-  <script type="text/babel" src="terminal/contributors-data.jsx?v=18"></script>
-  <script type="text/babel" src="terminal/dashboard.jsx?v=18"></script>
-  <script type="text/babel" src="terminal/contributors.jsx?v=18"></script>
-  <script type="text/babel" src="terminal/live-stamp.jsx?v=18"></script>
-  <script type="text/babel" src="terminal/app.jsx?v=18"></script>
+  <!-- useIsMobile must load before the views that branch on it for responsive reflow. -->
+  <script type="text/babel" src="terminal/use-viewport.jsx?v=19"></script>
+  <script type="text/babel" src="terminal/data.jsx?v=19"></script>
+  <script type="text/babel" src="terminal/contributors-data.jsx?v=19"></script>
+  <script type="text/babel" src="terminal/dashboard.jsx?v=19"></script>
+  <script type="text/babel" src="terminal/contributors.jsx?v=19"></script>
+  <script type="text/babel" src="terminal/live-stamp.jsx?v=19"></script>
+  <script type="text/babel" src="terminal/app.jsx?v=19"></script>
 
   <script type="text/babel">
     (async () => {

--- a/docs/index.html
+++ b/docs/index.html
@@ -68,17 +68,17 @@
   </div>
 
   <!-- Pure-JS helper for the LIVE chip, loadable in Node for unit testing. -->
-  <script src="terminal/live-stamp-format.js?v=19"></script>
+  <script src="terminal/live-stamp-format.js?v=20"></script>
 
   <!-- Cache-bust the bundle when its shape changes. Bump v= on data-shape edits. -->
   <!-- useIsMobile must load before the views that branch on it for responsive reflow. -->
-  <script type="text/babel" src="terminal/use-viewport.jsx?v=19"></script>
-  <script type="text/babel" src="terminal/data.jsx?v=19"></script>
-  <script type="text/babel" src="terminal/contributors-data.jsx?v=19"></script>
-  <script type="text/babel" src="terminal/dashboard.jsx?v=19"></script>
-  <script type="text/babel" src="terminal/contributors.jsx?v=19"></script>
-  <script type="text/babel" src="terminal/live-stamp.jsx?v=19"></script>
-  <script type="text/babel" src="terminal/app.jsx?v=19"></script>
+  <script type="text/babel" src="terminal/use-viewport.jsx?v=20"></script>
+  <script type="text/babel" src="terminal/data.jsx?v=20"></script>
+  <script type="text/babel" src="terminal/contributors-data.jsx?v=20"></script>
+  <script type="text/babel" src="terminal/dashboard.jsx?v=20"></script>
+  <script type="text/babel" src="terminal/contributors.jsx?v=20"></script>
+  <script type="text/babel" src="terminal/live-stamp.jsx?v=20"></script>
+  <script type="text/babel" src="terminal/app.jsx?v=20"></script>
 
   <script type="text/babel">
     (async () => {

--- a/docs/terminal/app.jsx
+++ b/docs/terminal/app.jsx
@@ -28,6 +28,7 @@ function NGApp() {
 }
 
 function TopBar({ tab, setTab }) {
+  const isMobile = useIsMobile();
   const TABS = [
     { id: 'hiring',       label: 'HIRING',       sub: `${NGJOBS.length} open` },
     { id: 'contributors', label: 'CONTRIBUTORS', sub: `${NGCONTRIB.length} devs` },
@@ -36,7 +37,12 @@ function TopBar({ tab, setTab }) {
     <div style={{
       display: 'flex', alignItems: 'stretch',
       borderBottom: '1px solid #2a2a2a', background: '#000',
-      fontSize: 12, height: 38,
+      fontSize: 12,
+      // Mobile: let the bar wrap so the meta cluster drops to its own row
+      // instead of forcing horizontal scroll on a phone.
+      height: isMobile ? 'auto' : 38,
+      minHeight: 38,
+      flexWrap: isMobile ? 'wrap' : 'nowrap',
     }}>
       {/* Brand */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '0 14px', borderRight: '1px solid #2a2a2a' }}>
@@ -58,6 +64,7 @@ function TopBar({ tab, setTab }) {
               borderBottom: active ? '2px solid #ff9d3d' : '2px solid transparent',
               color: active ? '#ff9d3d' : '#e8e8e8',
               padding: '0 18px',
+              minHeight: isMobile ? 44 : 'auto',  // comfortable touch target on phones
               fontFamily: 'inherit', fontSize: 12, fontWeight: active ? 700 : 500,
               cursor: 'pointer', letterSpacing: 0.5,
               display: 'flex', alignItems: 'center', gap: 8,
@@ -70,11 +77,19 @@ function TopBar({ tab, setTab }) {
       </div>
 
       {/* Right meta */}
-      <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 14, padding: '0 14px', fontSize: 11, color: '#6e6e6e' }}>
+      <div style={{
+        marginLeft: 'auto', display: 'flex', alignItems: 'center',
+        gap: isMobile ? 10 : 14, padding: isMobile ? '4px 12px' : '0 14px',
+        fontSize: 11, color: '#6e6e6e',
+        flexWrap: isMobile ? 'wrap' : 'nowrap',
+      }}>
         <LiveStamp />
         <SponsoredBy />
         <SponsorLink />
-        <span style={{ border: '1px solid #2a2a2a', padding: '2px 6px', color: '#e8e8e8' }}>F1 HELP</span>
+        {/* The F1 HELP hint is keyboard-only, so it's noise on touch. */}
+        {!isMobile && (
+          <span style={{ border: '1px solid #2a2a2a', padding: '2px 6px', color: '#e8e8e8' }}>F1 HELP</span>
+        )}
       </div>
     </div>
   );
@@ -85,6 +100,7 @@ function SiteFooter() {
   // layout (nav links / socials / version+copyright) to our terminal palette.
   // Right-aligned within a thin row beneath the tab-level status bar so it
   // doesn't overlap the dense main content above.
+  const isMobile = useIsMobile();
   const REPO = 'https://github.com/ambicuity/New-Grad-Jobs';
   const links = [
     { href: REPO,                                    label: 'Repo',   ext: true },
@@ -100,9 +116,9 @@ function SiteFooter() {
   ];
   return (
     <div style={{
-      display: 'flex', justifyContent: 'flex-end',
+      display: 'flex', justifyContent: isMobile ? 'center' : 'flex-end',
       borderTop: '1px solid #2a2a2a', background: '#0a0a0a',
-      padding: '4px 14px', gap: 14,
+      padding: isMobile ? '6px 10px' : '4px 14px', gap: isMobile ? 10 : 14,
       fontSize: 10, color: '#6e6e6e', letterSpacing: 0.3, flexWrap: 'wrap',
     }}>
       <FooterRow items={links} />

--- a/docs/terminal/contributors.jsx
+++ b/docs/terminal/contributors.jsx
@@ -183,7 +183,9 @@ function ContributorsView() {
           <div style={{ padding:'12px 14px', borderTop: `1px solid ${CBG.rule}` }}>
             <div style={{ color: CBG.dim, fontSize: 10, letterSpacing: 0.7, marginBottom: 6 }}>TOP BY COMMITS</div>
             {top5.map((c, i) => (
-              <div key={c.handle} onClick={() => setSelectedHandle(c.handle)} style={{
+              <div key={c.handle}
+                onClick={() => { setSelectedHandle(c.handle); if (isMobile) setMobileDetailOpen(true); }}
+                style={{
                 display:'grid', gridTemplateColumns:'14px 1fr auto', gap: 6, padding:'2px 0',
                 cursor:'pointer', fontSize: 11,
               }}>
@@ -254,8 +256,13 @@ function ContributorsView() {
               const isSel = c.handle === selectedHandle;
               if (isMobile) {
                 // Single-column card; tap opens the full-screen contributor detail.
+                const openDetail = () => { setSelectedHandle(c.handle); setMobileDetailOpen(true); };
                 return (
-                  <div key={c.handle} onClick={() => { setSelectedHandle(c.handle); setMobileDetailOpen(true); }} style={{
+                  <div key={c.handle} onClick={openDetail}
+                    role="button" tabIndex={0}
+                    aria-label={`@${c.handle} — ${c.name}, open details`}
+                    onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetail(); } }}
+                    style={{
                     padding:'11px 14px', borderBottom: `1px solid ${CBG.rule}`,
                     cursor:'pointer', display:'flex', flexDirection:'column', gap: 5,
                   }}>

--- a/docs/terminal/contributors.jsx
+++ b/docs/terminal/contributors.jsx
@@ -18,6 +18,11 @@ function ContributorsView() {
   const [sortKey, setSortKey] = useStateC('commits');
   const [sortDir, setSortDir] = useStateC(1);
   const [selectedHandle, setSelectedHandle] = useStateC(NGCONTRIB[0].handle);
+  // Mobile reflow: the repo card + filters + leaderboard collapse into a drawer,
+  // and tapping a contributor opens a full-screen detail (no 460px side panel).
+  const isMobile = useIsMobile();
+  const [drawerOpen, setDrawerOpen] = useStateC(false);
+  const [mobileDetailOpen, setMobileDetailOpen] = useStateC(false);
   const searchRef = useRefC(null);
 
   const toggleSet = (key, val) => setFilters(f => {
@@ -82,16 +87,48 @@ function ContributorsView() {
 
   return (
     <div style={{
-      width:'100%', minWidth: 1180, height:'100%', minHeight: 640, background: CBG.bg, color: CBG.ink,
+      width:'100%', minWidth: isMobile ? 0 : 1180,
+      height:'100%', minHeight: isMobile ? 0 : 640, background: CBG.bg, color: CBG.ink,
       fontFamily:'"JetBrains Mono", ui-monospace, monospace', fontSize: 12, lineHeight: 1.45,
       display:'grid', gridTemplateRows:'1fr auto', overflow:'hidden', position:'relative',
     }}>
 
       {/* Body */}
-      <div style={{ display:'grid', gridTemplateColumns:'220px 1fr 460px', minHeight: 0 }}>
+      <div style={{
+        display: isMobile ? 'block' : 'grid',
+        gridTemplateColumns: isMobile ? undefined : '220px 1fr 460px',
+        minHeight: 0,
+        overflowY: isMobile ? 'auto' : 'hidden',
+      }}>
 
         {/* Left rail: repo card + filters + leaderboard */}
-        <div style={{ borderRight: `1px solid ${CBG.rule2}`, overflow:'auto' }}>
+        <div style={{
+          borderRight: isMobile ? 'none' : `1px solid ${CBG.rule2}`,
+          borderBottom: isMobile ? `1px solid ${CBG.rule2}` : 'none',
+          overflow: isMobile ? 'visible' : 'auto',
+        }}>
+
+          {isMobile && (
+            <button
+              onClick={() => setDrawerOpen(o => !o)}
+              aria-expanded={drawerOpen}
+              style={{
+                width: '100%', display: 'flex', alignItems: 'center', gap: 8,
+                background: CBG.panel2, border: 'none', borderBottom: `1px solid ${CBG.rule2}`,
+                color: CBG.ink, fontFamily: 'inherit', fontSize: 12, letterSpacing: 0.6,
+                padding: '12px 14px', cursor: 'pointer', minHeight: 44, textAlign: 'left',
+              }}
+            >
+              <span style={{ color: CBG.acc }}>{drawerOpen ? '▾' : '▸'}</span>
+              <span>REPO · FILTERS · TOP</span>
+              {(() => {
+                const n = filters.role.size + filters.area.size + filters.lang.size;
+                return n ? <span style={{ color: CBG.acc }}>· {n} active</span> : null;
+              })()}
+            </button>
+          )}
+          {(!isMobile || drawerOpen) && (
+          <React.Fragment>
 
           {/* Repo card */}
           <div style={{ padding:'14px 14px 12px', borderBottom: `1px solid ${CBG.rule2}` }}>
@@ -156,18 +193,27 @@ function ContributorsView() {
               </div>
             ))}
           </div>
+          </React.Fragment>
+          )}
         </div>
 
         {/* Center: header strip + table */}
-        <div style={{ display:'flex', flexDirection:'column', minHeight: 0, borderRight: `1px solid ${CBG.rule2}` }}>
+        <div style={{ display:'flex', flexDirection:'column', minHeight: 0, borderRight: isMobile ? 'none' : `1px solid ${CBG.rule2}` }}>
           {/* Stats strip */}
-          <div style={{ display:'flex', gap: 18, padding:'10px 14px', borderBottom: `1px solid ${CBG.rule2}`, alignItems:'center' }}>
+          <div style={{
+            display:'flex', gap: isMobile ? 12 : 18, padding:'10px 14px',
+            borderBottom: `1px solid ${CBG.rule2}`, alignItems:'center',
+            flexWrap: isMobile ? 'wrap' : 'nowrap',
+          }}>
             <CStat label="CONTRIBUTORS" value={NGCONTRIB.length} delta={`+3 7d`} deltaC={CBG.ok} />
             <CStat label="COMMITS"      value={fmtK(totals.commits)} delta="+412 7d" deltaC={CBG.ok} />
             <CStat label="PRS MERGED"   value={fmtK(totals.prs)}     delta="+98 7d"  deltaC={CBG.ok} />
             <CStat label="ACTIVE 7D"    value={activeWeek}            delta=""        deltaC={CBG.dim} />
             <CStat label="NET LOC"      value={`+${fmtK(totals.add)} / -${fmtK(totals.del)}`} delta="" deltaC={CBG.dim} />
-            <div style={{ marginLeft:'auto', display:'flex', gap: 8, alignItems:'center' }}>
+            <div style={{
+              marginLeft: isMobile ? 0 : 'auto', width: isMobile ? '100%' : 'auto',
+              display:'flex', gap: 8, alignItems:'center',
+            }}>
               <span style={{ color: CBG.acc, fontWeight: 700 }}>CMD&gt;</span>
               <input
                 ref={searchRef}
@@ -176,13 +222,14 @@ function ContributorsView() {
                 style={{
                   background:'transparent', border: `1px solid ${CBG.rule2}`, outline:'none',
                   color: CBG.ink, fontFamily:'inherit', fontSize: 12, padding:'3px 8px',
-                  width: 260, letterSpacing: 0.3,
+                  width: isMobile ? 'auto' : 260, flex: isMobile ? 1 : 'none', letterSpacing: 0.3,
                 }}
               />
             </div>
           </div>
 
-          {/* Tabular header */}
+          {/* Tabular header — desktop only; mobile cards carry their own labels */}
+          {!isMobile && (
           <div style={{
             display:'grid',
             gridTemplateColumns:'32px 130px 1fr 90px 70px 60px 110px 80px 70px',
@@ -199,11 +246,41 @@ function ContributorsView() {
             <CSortHdr k="since"   label="SINCE"   cur={sortKey} dir={sortDir} on={sortClick} />
             <CSortHdr k="last"    label="LAST"    cur={sortKey} dir={sortDir} on={sortClick} />
           </div>
+          )}
 
           {/* Rows */}
           <div style={{ overflow:'auto', flex: 1 }}>
             {filtered.map((c, i) => {
               const isSel = c.handle === selectedHandle;
+              if (isMobile) {
+                // Single-column card; tap opens the full-screen contributor detail.
+                return (
+                  <div key={c.handle} onClick={() => { setSelectedHandle(c.handle); setMobileDetailOpen(true); }} style={{
+                    padding:'11px 14px', borderBottom: `1px solid ${CBG.rule}`,
+                    cursor:'pointer', display:'flex', flexDirection:'column', gap: 5,
+                  }}>
+                    <div style={{ display:'flex', alignItems:'center', gap: 8 }}>
+                      <span style={{ color: CBG.dim, fontSize: 11 }}>{String(i+1).padStart(2,'0')}</span>
+                      <Avatar handle={c.handle} size={22} />
+                      <span style={{ color: CBG.acc, fontWeight: 600, fontSize: 12.5 }}>@{c.handle}</span>
+                      <span style={{ color: roleColor(c.role), fontSize: 10, letterSpacing: 0.5, marginLeft: 'auto' }}>{c.role.toUpperCase()}</span>
+                    </div>
+                    <div style={{ color: CBG.ink, fontSize: 12.5 }}>{c.name}</div>
+                    <div style={{ color: CBG.dim, fontSize: 11, display:'flex', flexWrap:'wrap', alignItems:'center', gap:'2px 6px' }}>
+                      <span>{c.region}</span>
+                      <span style={{ color: CBG.rule2 }}>·</span>
+                      <span style={{ color: CBG.acc }}>{c.commits.toLocaleString()} commits</span>
+                      <span style={{ color: CBG.rule2 }}>·</span>
+                      <span>{c.prs} prs</span>
+                      <span style={{ color: CBG.rule2 }}>·</span>
+                      <span style={{ color: CBG.ok }}>+{fmtK(c.add)}</span>
+                      <span style={{ color: CBG.hot }}>-{fmtK(c.del)}</span>
+                      <span style={{ color: CBG.rule2 }}>·</span>
+                      <span style={{ color: /h$|^1d/.test(c.last) ? CBG.ok : CBG.ink }}>{c.last}</span>
+                    </div>
+                  </div>
+                );
+              }
               return (
                 <div key={c.handle} onClick={() => setSelectedHandle(c.handle)} style={{
                   display:'grid',
@@ -250,9 +327,35 @@ function ContributorsView() {
           </div>
         </div>
 
-        {/* Right: contributor detail */}
-        <ContribDetail c={selected} spark={spark} />
+        {/* Right: contributor detail (desktop inline; mobile = full-screen overlay below) */}
+        {!isMobile && <ContribDetail c={selected} spark={spark} />}
       </div>
+
+      {/* Mobile: full-screen contributor detail, opened by tapping a card. */}
+      {isMobile && mobileDetailOpen && selected && (
+        <div style={{
+          position: 'fixed', inset: 0, zIndex: 50, background: CBG.bg,
+          display: 'flex', flexDirection: 'column',
+        }}>
+          <div style={{
+            display: 'flex', alignItems: 'center', gap: 10,
+            borderBottom: `1px solid ${CBG.rule2}`, background: CBG.panel,
+            padding: '0 6px', minHeight: 48, flexShrink: 0,
+          }}>
+            <button onClick={() => setMobileDetailOpen(false)} aria-label="Back to contributor list" style={{
+              background: 'transparent', border: 'none', color: CBG.acc, cursor: 'pointer',
+              fontFamily: 'inherit', fontSize: 14, fontWeight: 600, padding: '12px 10px', minHeight: 44,
+            }}>‹ BACK</button>
+            <span style={{
+              color: CBG.dim, fontSize: 12, overflow: 'hidden',
+              textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            }}>@{selected.handle} · {selected.name}</span>
+          </div>
+          <div style={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
+            <ContribDetail c={selected} spark={spark} />
+          </div>
+        </div>
+      )}
 
       {/* Footer */}
       <div style={{
@@ -262,12 +365,14 @@ function ContributorsView() {
         <span>STATUS: <span style={{ color: CBG.ok }}>OK</span></span>
         <span>SHOWN: <span style={{ color: CBG.ink }}>{filtered.length}</span> / {NGCONTRIB.length}</span>
         <span>SEL: <span style={{ color: CBG.ink }}>@{selected?.handle || '—'}</span></span>
-        <span style={{ marginLeft:'auto', display:'flex', gap: 14 }}>
-          <FKeyC n="/"   l="SEARCH" />
-          <FKeyC n="F2"  l="SORT" />
-          <FKeyC n="ESC" l="CLEAR" />
-          <FKeyC n="G"   l="GITHUB \u2197" />
-        </span>
+        {!isMobile && (
+          <span style={{ marginLeft:'auto', display:'flex', gap: 14 }}>
+            <FKeyC n="/"   l="SEARCH" />
+            <FKeyC n="F2"  l="SORT" />
+            <FKeyC n="ESC" l="CLEAR" />
+            <FKeyC n="G"   l="GITHUB \u2197" />
+          </span>
+        )}
       </div>
     </div>
   );
@@ -377,7 +482,7 @@ function ContribDetail({ c, spark }) {
 
 function CStat({ label, value, delta, deltaC }) {
   return (
-    <div style={{ display:'flex', flexDirection:'column', minWidth: 56 }}>
+    <div style={{ display:'flex', flexDirection:'column', minWidth: 56, flexShrink: 0 }}>
       <span style={{ fontSize: 9.5, color: CBG.dim, letterSpacing: 0.8 }}>{label}</span>
       <span style={{ fontSize: 14, color: CBG.ink, fontWeight: 600, lineHeight: 1.15 }}>{value}</span>
       {delta && <span style={{ fontSize: 9.5, color: deltaC || CBG.dim }}>{delta}</span>}

--- a/docs/terminal/dashboard.jsx
+++ b/docs/terminal/dashboard.jsx
@@ -313,7 +313,7 @@ function DashboardDirection() {
         </div>
 
         {/* ─ Center: search + tabular list ─ */}
-        <div style={{ display: 'flex', flexDirection: 'column', minHeight: 0, borderRight: `1px solid ${BBG.rule2}` }}>
+        <div style={{ display: 'flex', flexDirection: 'column', minHeight: 0, borderRight: isMobile ? 'none' : `1px solid ${BBG.rule2}` }}>
           <div style={{ padding: '8px 14px', borderBottom: `1px solid ${BBG.rule2}`, display: 'flex', alignItems: 'center', gap: 10 }}>
             <span style={{ color: BBG.acc, fontWeight: 700 }}>CMD&gt;</span>
             <input
@@ -359,8 +359,13 @@ function DashboardDirection() {
               if (isMobile) {
                 // Single-column card: the 8 desktop columns can't fit a phone,
                 // so stack them and open the full-screen detail on tap.
+                const openDetail = () => { setSelectedId(j.id); setMobileDetailOpen(true); };
                 return (
-                  <div key={j.id} onClick={() => { setSelectedId(j.id); setMobileDetailOpen(true); }} style={{
+                  <div key={j.id} onClick={openDetail}
+                    role="button" tabIndex={0}
+                    aria-label={`${j.co} — ${j.role}, open details`}
+                    onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetail(); } }}
+                    style={{
                     padding: '11px 14px', borderBottom: `1px solid ${BBG.rule}`,
                     cursor: 'pointer', display: 'flex', flexDirection: 'column', gap: 4,
                   }}>

--- a/docs/terminal/dashboard.jsx
+++ b/docs/terminal/dashboard.jsx
@@ -35,6 +35,11 @@ function DashboardDirection() {
   const [savedOnly, setSavedOnly] = useState2(false);
   const [toast, setToast] = useState2(null);
   const [helpOpen, setHelpOpen] = useState2(false);
+  // Mobile reflow state: filters collapse into a drawer, and tapping a job
+  // opens a full-screen detail view (there's no room for the 460px side panel).
+  const isMobile = useIsMobile();
+  const [filtersOpen, setFiltersOpen] = useState2(false);
+  const [mobileDetailOpen, setMobileDetailOpen] = useState2(false);
   const searchRef = useRef2(null);
   const listScrollRef = useRef2(null);
 
@@ -163,24 +168,62 @@ function DashboardDirection() {
 
   return (
     <div style={{
-      width: '100%', minWidth: 1180, height: '100%', minHeight: 640, background: BBG.bg, color: BBG.ink,
+      width: '100%', minWidth: isMobile ? 0 : 1180,
+      height: '100%', minHeight: isMobile ? 0 : 640, background: BBG.bg, color: BBG.ink,
       fontFamily: '"JetBrains Mono", ui-monospace, monospace', fontSize: 12, lineHeight: 1.45,
       display: 'grid', gridTemplateRows: 'auto 1fr auto', overflow: 'hidden', position: 'relative',
     }}>
       {/* ─── Stats strip ─── */}
-      <div style={{ display: 'flex', alignItems: 'center', borderBottom: `1px solid ${BBG.rule2}`, padding: '10px 14px', gap: 18 }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', borderBottom: `1px solid ${BBG.rule2}`,
+        padding: '10px 14px', gap: isMobile ? 14 : 18,
+        // Phones can't fit 5 stats side-by-side; let them scroll horizontally
+        // rather than wrap or shrink below legibility.
+        overflowX: isMobile ? 'auto' : 'visible',
+      }}>
         <Stat label="OPEN"      value={NGJOBS.length} delta="+12 24h" deltaC={BBG.ok} />
         <Stat label="NEW TODAY" value={NGJOBS.filter(j => /^\dh|^1d|^2d/.test(j.posted)).length} delta="+5"   deltaC={BBG.ok} />
         <Stat label="CLOSING <7d" value={NGJOBS.filter(j => daysLeft(j.dl) < 7).length} delta="⚠" deltaC={BBG.hot} />
         <Stat label="MED COMP" value="$170k" delta="+2.1%" deltaC={BBG.ok} />
         <Stat label="VISA✓"    value={`${Math.round(100*NGJOBS.filter(j=>j.visa).length/NGJOBS.length)}%`} delta="" deltaC={BBG.dim} />
-        <div style={{ marginLeft: 'auto', color: BBG.dim, fontSize: 11 }}>HIRING · live job feed</div>
+        {!isMobile && <div style={{ marginLeft: 'auto', color: BBG.dim, fontSize: 11 }}>HIRING · live job feed</div>}
       </div>
 
       {/* ─── Body grid ─── */}
-      <div style={{ display: 'grid', gridTemplateColumns: '210px 1fr 460px', minHeight: 0 }}>
+      <div style={{
+        display: isMobile ? 'block' : 'grid',
+        gridTemplateColumns: isMobile ? undefined : '210px 1fr 460px',
+        minHeight: 0,
+        overflowY: isMobile ? 'auto' : 'hidden',
+      }}>
         {/* ─ Left rail: filters as compact chip list ─ */}
-        <div style={{ borderRight: `1px solid ${BBG.rule2}`, overflow: 'auto' }}>
+        <div style={{
+          borderRight: isMobile ? 'none' : `1px solid ${BBG.rule2}`,
+          borderBottom: isMobile ? `1px solid ${BBG.rule2}` : 'none',
+          overflow: isMobile ? 'visible' : 'auto',
+        }}>
+          {isMobile && (
+            <button
+              onClick={() => setFiltersOpen(o => !o)}
+              aria-expanded={filtersOpen}
+              style={{
+                width: '100%', display: 'flex', alignItems: 'center', gap: 8,
+                background: BBG.panel2, border: 'none', borderBottom: `1px solid ${BBG.rule2}`,
+                color: BBG.ink, fontFamily: 'inherit', fontSize: 12, letterSpacing: 0.6,
+                padding: '12px 14px', cursor: 'pointer', minHeight: 44, textAlign: 'left',
+              }}
+            >
+              <span style={{ color: BBG.acc }}>{filtersOpen ? '▾' : '▸'}</span>
+              <span>FILTERS</span>
+              {(() => {
+                const n = filters.type.size + filters.rmt.size + (filters.visa !== null ? 1 : 0)
+                  + filters.size.size + filters.company.size;
+                return n ? <span style={{ color: BBG.acc }}>· {n} active</span> : null;
+              })()}
+            </button>
+          )}
+          {(!isMobile || filtersOpen) && (
+          <React.Fragment>
           <ChipGroup title="ROLE">
             {['SWE','FE','BE','MOBILE','SEC','ML','DATA','INFRA','PM','QUANT','HW','OTHER'].map(t => (
               <Chip key={t} on={filters.type.has(t)} onClick={() => toggleSet('type', t)} label={TYPE_LABEL[t]} />
@@ -265,6 +308,8 @@ function DashboardDirection() {
               })}
             </div>
           </div>
+          </React.Fragment>
+          )}
         </div>
 
         {/* ─ Center: search + tabular list ─ */}
@@ -286,7 +331,8 @@ function DashboardDirection() {
             </span>
           </div>
 
-          {/* Tabular header */}
+          {/* Tabular header — desktop only; mobile cards carry their own labels */}
+          {!isMobile && (
           <div style={{
             display: 'grid',
             gridTemplateColumns: '28px 110px 1fr 130px 90px 90px 90px 26px',
@@ -302,6 +348,7 @@ function DashboardDirection() {
             <SortHeader k="deadline" label="DEADLINE"  cur={sortKey} dir={sortDir} onClick={sortClick} />
             <span></span>
           </div>
+          )}
 
           <div style={{ overflow: 'auto', flex: 1 }}>
             {filtered.map((j, i) => {
@@ -309,6 +356,39 @@ function DashboardDirection() {
               const isSaved = saved.has(j.id);
               const days = daysLeft(j.dl);
               const urgency = Math.min(1, Math.max(0, 1 - days/120));
+              if (isMobile) {
+                // Single-column card: the 8 desktop columns can't fit a phone,
+                // so stack them and open the full-screen detail on tap.
+                return (
+                  <div key={j.id} onClick={() => { setSelectedId(j.id); setMobileDetailOpen(true); }} style={{
+                    padding: '11px 14px', borderBottom: `1px solid ${BBG.rule}`,
+                    cursor: 'pointer', display: 'flex', flexDirection: 'column', gap: 4,
+                  }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
+                      <span style={{ color: BBG.acc, fontWeight: 600, fontSize: 12.5 }}>
+                        <span style={{ color: BBG.dim, marginRight: 6 }}>{String(i+1).padStart(2,'0')}</span>{j.co}
+                      </span>
+                      <button onClick={(e) => { e.stopPropagation(); toggleSave(j.id); }}
+                        aria-label={isSaved ? 'unsave job' : 'save job'} style={{
+                        background: 'transparent', border: 'none', cursor: 'pointer', padding: '2px 4px',
+                        color: isSaved ? BBG.acc : BBG.dim, fontFamily: 'inherit', fontSize: 18, lineHeight: 1,
+                      }}>{isSaved ? '★' : '☆'}</button>
+                    </div>
+                    <div style={{ color: BBG.ink, fontSize: 13, lineHeight: 1.3 }}>{j.role}</div>
+                    <div style={{ color: BBG.dim, fontSize: 11, display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '2px 6px' }}>
+                      <span>{j.loc}</span>
+                      <span style={{ color: BBG.rule2 }}>·</span>
+                      <span style={{ color: BBG.acc }}>{fmtComp(j.comp)}</span>
+                      <span style={{ color: BBG.rule2 }}>·</span>
+                      <span>{j.posted}</span>
+                      <span style={{ color: BBG.rule2 }}>·</span>
+                      <span style={{ color: days < 14 ? BBG.hot : BBG.ink }}>{days < 0 ? 'closed' : `${days}d left`}</span>
+                      <span style={{ color: BBG.rule2 }}>·</span>
+                      <span style={{ color: j.visa ? BBG.ok : BBG.warn }}>{j.visa ? 'visa✓' : 'us'}</span>
+                    </div>
+                  </div>
+                );
+              }
               return (
                 <div key={j.id} onClick={() => setSelectedId(j.id)} style={{
                   display: 'grid',
@@ -359,9 +439,37 @@ function DashboardDirection() {
           </div>
         </div>
 
-        {/* ─ Right: detail card ─ */}
-        <DashboardDetail job={selected} saved={saved.has(selected?.id)} onSave={() => toggleSave(selected.id)} />
+        {/* ─ Right: detail card (desktop inline; on mobile it's a full-screen overlay below) ─ */}
+        {!isMobile && (
+          <DashboardDetail job={selected} saved={saved.has(selected?.id)} onSave={() => toggleSave(selected.id)} />
+        )}
       </div>
+
+      {/* Mobile: full-screen job detail, opened by tapping a card. */}
+      {isMobile && mobileDetailOpen && selected && (
+        <div style={{
+          position: 'fixed', inset: 0, zIndex: 50, background: BBG.bg,
+          display: 'flex', flexDirection: 'column',
+        }}>
+          <div style={{
+            display: 'flex', alignItems: 'center', gap: 10,
+            borderBottom: `1px solid ${BBG.rule2}`, background: BBG.panel,
+            padding: '0 6px', minHeight: 48, flexShrink: 0,
+          }}>
+            <button onClick={() => setMobileDetailOpen(false)} aria-label="Back to job list" style={{
+              background: 'transparent', border: 'none', color: BBG.acc, cursor: 'pointer',
+              fontFamily: 'inherit', fontSize: 14, fontWeight: 600, padding: '12px 10px', minHeight: 44,
+            }}>‹ BACK</button>
+            <span style={{
+              color: BBG.dim, fontSize: 12, overflow: 'hidden',
+              textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            }}>{selected.co} · {selected.role}</span>
+          </div>
+          <div style={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
+            <DashboardDetail job={selected} saved={saved.has(selected?.id)} onSave={() => toggleSave(selected.id)} />
+          </div>
+        </div>
+      )}
 
       {/* Toast */}
       {toast && (
@@ -441,15 +549,17 @@ function DashboardDirection() {
         >
           SAVED: <span style={{ color: savedOnly ? '#000' : BBG.acc, fontWeight: 700 }}>{saved.size}</span>
         </span>
-        <span style={{ marginLeft: 'auto', display: 'flex', gap: 14 }}>
-          <FKey n="/"   l="SEARCH" />
-          <FKey n="↑↓"  l="NAV" />
-          <FKey n="⏎"   l="APPLY" />
-          <FKey n="S"   l="SAVE" />
-          <FKey n="F2"  l="SORT" />
-          <FKey n="ESC" l="CLEAR" />
-          <FKey n="?"   l="HELP" />
-        </span>
+        {!isMobile && (
+          <span style={{ marginLeft: 'auto', display: 'flex', gap: 14 }}>
+            <FKey n="/"   l="SEARCH" />
+            <FKey n="↑↓"  l="NAV" />
+            <FKey n="⏎"   l="APPLY" />
+            <FKey n="S"   l="SAVE" />
+            <FKey n="F2"  l="SORT" />
+            <FKey n="ESC" l="CLEAR" />
+            <FKey n="?"   l="HELP" />
+          </span>
+        )}
       </div>
     </div>
   );
@@ -457,7 +567,7 @@ function DashboardDirection() {
 
 function Stat({ label, value, delta, deltaC }) {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', minWidth: 56 }}>
+    <div style={{ display: 'flex', flexDirection: 'column', minWidth: 56, flexShrink: 0 }}>
       <span style={{ fontSize: 9.5, color: BBG.dim, letterSpacing: 0.8 }}>{label}</span>
       <span style={{ fontSize: 14, color: BBG.ink, fontWeight: 600, lineHeight: 1.15 }}>{value}</span>
       {delta && <span style={{ fontSize: 9.5, color: deltaC || BBG.dim }}>{delta}</span>}

--- a/docs/terminal/use-viewport.jsx
+++ b/docs/terminal/use-viewport.jsx
@@ -1,0 +1,38 @@
+// Shared responsive hook. The terminal views are styled entirely with inline JS
+// style objects, which win specificity over stylesheet rules — so `@media`
+// queries can't restyle them. Responsive branching is therefore driven in JS:
+// components call `useIsMobile()` and swap their inline styles on the result.
+//
+// Single source of truth for the breakpoint. Below MOBILE_MAX the layout
+// collapses to a single column; at/above it the desktop terminal is unchanged.
+
+const MOBILE_MAX_PX = 760;
+const MOBILE_QUERY = `(max-width: ${MOBILE_MAX_PX}px)`;
+
+function useIsMobile() {
+  const mql = React.useMemo(
+    () => (typeof window !== 'undefined' && window.matchMedia
+      ? window.matchMedia(MOBILE_QUERY)
+      : null),
+    [],
+  );
+  const [isMobile, setIsMobile] = React.useState(() => (mql ? mql.matches : false));
+
+  React.useEffect(() => {
+    if (!mql) return undefined;
+    const onChange = (e) => setIsMobile(e.matches);
+    // Safari < 14 lacks addEventListener on MediaQueryList; fall back to the
+    // deprecated addListener so older iOS still gets live breakpoint updates.
+    if (mql.addEventListener) {
+      mql.addEventListener('change', onChange);
+      return () => mql.removeEventListener('change', onChange);
+    }
+    mql.addListener(onChange);
+    return () => mql.removeListener(onChange);
+  }, [mql]);
+
+  return isMobile;
+}
+
+window.useIsMobile = useIsMobile;
+window.MOBILE_MAX_PX = MOBILE_MAX_PX;


### PR DESCRIPTION
Closes #346

## What

The `docs/` terminal dashboard was desktop-only — `#root` forced a 1180px canvas and both tabs used fixed 3-column grids with dense tabular rows, so phones got horizontal scroll. This makes both tabs reflow to a single, thumb-friendly column below **760px**, while leaving the desktop layout **byte-for-byte unchanged**.

Every view is styled with inline JS style objects (which beat stylesheet rules), so responsiveness is driven in JS by a shared `useIsMobile()` `matchMedia` hook rather than CSS media queries.

## Changes

- **`docs/terminal/use-viewport.jsx`** (new): `useIsMobile()` at a 760px breakpoint (single source of truth), with a Safari `addListener` fallback.
- **`index.html`**: relax `#root` min-width / `body` overflow on mobile via `@media` queries; load the hook first; bump cache-bust `?v=18 → ?v=19`.
- **`app.jsx`**: TopBar wraps with 44px tab touch targets and a condensed meta cluster; footer padding tightened; the keyboard-only `F1 HELP` hint is hidden on mobile.
- **`dashboard.jsx`** (Hiring): filters collapse into a `▸ FILTERS` drawer (with active-count badge); stats strip scrolls horizontally; rows become cards; tapping a card opens a **full-screen detail with a `‹ BACK` bar**; F-key hints hidden.
- **`contributors.jsx`**: same single-column treatment — `REPO · FILTERS · TOP` drawer, full-width search, contributor cards, full-screen contributor detail.

## Test plan

Verified locally with Playwright against the live `docs/` bundle:

- [x] **320px** — Hiring + Contributors lists, no horizontal overflow
- [x] **375px** — job cards, FILTERS drawer opens/closes, card → full-screen detail → BACK returns to list; contributor cards → full-screen detail
- [x] **1440px** — desktop 3-column layout intact on **both** tabs (column headers, side panels, F-key hints, `F1 HELP` chip)
- [x] `document.documentElement.scrollWidth === innerWidth` at 320 and 375 (no sideways scroll)
- [x] 0 console errors throughout
- [x] `pre-commit run --files …` passes on all touched files

Desktop behavior at ≥760px is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added responsive mobile layouts for dashboard and contributor views, including collapsible filters and repository navigation controls.
  * Introduced full-screen detail overlays for jobs and contributors with back navigation.
  * Updated terminal header/footer and touch controls for improved mobile usability.
  * Added a shared viewport-based mobile detection utility to drive responsive behavior.
* **Bug Fixes**
  * Prevented horizontal scrolling on small screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->