### PR TITLE
feat(frontend): reflow tablets too — raise mobile breakpoint to 1180px

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -27,10 +27,12 @@
     body { overflow-x: auto; }
     * { box-sizing: border-box; }
     #root { height: 100%; width: 100%; min-width: 1180px; }
-    /* Mobile: drop the desktop 1180px canvas so the single-column reflow
+    /* Mobile/tablet: drop the desktop 1180px canvas so the single-column reflow
        (driven by useIsMobile in the terminal views) fits the viewport with
-       no sideways scroll. Breakpoint mirrors MOBILE_MAX_PX in use-viewport.jsx. */
-    @media (max-width: 760px) {
+       no sideways scroll. Breakpoint mirrors MOBILE_MAX_PX in use-viewport.jsx —
+       it matches the desktop terminal's 1180px min-width, so any screen that
+       can't fit the 3-column layout reflows instead of scrolling. */
+    @media (max-width: 1180px) {
       body { overflow-x: hidden; }
       #root { min-width: 0; }
     }
@@ -68,17 +70,17 @@
   </div>
 
   <!-- Pure-JS helper for the LIVE chip, loadable in Node for unit testing. -->
-  <script src="terminal/live-stamp-format.js?v=20"></script>
+  <script src="terminal/live-stamp-format.js?v=21"></script>
 
   <!-- Cache-bust the bundle when its shape changes. Bump v= on data-shape edits. -->
   <!-- useIsMobile must load before the views that branch on it for responsive reflow. -->
-  <script type="text/babel" src="terminal/use-viewport.jsx?v=20"></script>
-  <script type="text/babel" src="terminal/data.jsx?v=20"></script>
-  <script type="text/babel" src="terminal/contributors-data.jsx?v=20"></script>
-  <script type="text/babel" src="terminal/dashboard.jsx?v=20"></script>
-  <script type="text/babel" src="terminal/contributors.jsx?v=20"></script>
-  <script type="text/babel" src="terminal/live-stamp.jsx?v=20"></script>
-  <script type="text/babel" src="terminal/app.jsx?v=20"></script>
+  <script type="text/babel" src="terminal/use-viewport.jsx?v=21"></script>
+  <script type="text/babel" src="terminal/data.jsx?v=21"></script>
+  <script type="text/babel" src="terminal/contributors-data.jsx?v=21"></script>
+  <script type="text/babel" src="terminal/dashboard.jsx?v=21"></script>
+  <script type="text/babel" src="terminal/contributors.jsx?v=21"></script>
+  <script type="text/babel" src="terminal/live-stamp.jsx?v=21"></script>
+  <script type="text/babel" src="terminal/app.jsx?v=21"></script>
 
   <script type="text/babel">
     (async () => {

--- a/docs/terminal/use-viewport.jsx
+++ b/docs/terminal/use-viewport.jsx
@@ -5,8 +5,14 @@
 //
 // Single source of truth for the breakpoint. Below MOBILE_MAX the layout
 // collapses to a single column; at/above it the desktop terminal is unchanged.
+//
+// The value is tied to the desktop terminal's own min-width (1180px): any
+// viewport that can't fit the 3-column terminal reflows to a single column, so
+// there is no in-between band that horizontally scrolls. This means phones AND
+// tablets (portrait + landscape) get the single-column layout; only ≥1180px
+// screens, where the terminal fits, keep the dense desktop view.
 
-const MOBILE_MAX_PX = 760;
+const MOBILE_MAX_PX = 1180;
 const MOBILE_QUERY = `(max-width: ${MOBILE_MAX_PX}px)`;
 
 function useIsMobile() {


### PR DESCRIPTION
Closes #348 · follow-up to #346 / #347

## Problem

The 760px breakpoint left the **761–1180px band** in desktop mode. Because the 3-column terminal has a `1180px` min-width, portrait tablets (768) and landscape tablets (iPad 1080, iPad mini 1133) rendered the desktop terminal and scrolled horizontally.

## Fix

Tie the breakpoint to the terminal's own min-width. Any viewport that can't fit the 3-column terminal reflows to a single column — no in-between scroll band.

- `use-viewport.jsx`: `MOBILE_MAX_PX` 760 → **1180** (single source of truth)
- `index.html`: matching `@media (max-width: …)` 760 → **1180**; cache-bust `?v=20 → ?v=21`

| Range | Behavior |
|-------|----------|
| ≤ 1180px | single-column reflow (phones + all tablets) |
| > 1180px | desktop 3-column terminal (fits, no scroll) |

## Test plan

Playwright on both tabs at **375 / 768 / 1024 / 1180 / 1181 / 1920**:

- [x] 768, 1024, 1133, 1180 → reflow, **no horizontal overflow** (previously scrolled)
- [x] transition is exactly at 1180 (reflow) / 1181 (desktop)
- [x] 1181 & 1920 → desktop 3-column layout unchanged
- [x] 375 → phone layout unchanged
- [x] Contributors tab reflows at 1024 too (shared `useIsMobile`)
- [x] 0 console errors; `pre-commit` passes on touched files